### PR TITLE
[Backport] 8333462: Performance regression of new DecimalFormat() when compare to jdk11

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -849,10 +849,13 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * Obtains non-format single character from String
      */
     private char findNonFormatChar(String src, char defChar) {
-        return (char)src.chars()
-            .filter(c -> Character.getType(c) != Character.FORMAT)
-            .findFirst()
-            .orElse(defChar);
+        for (int i = 0; i < src.length(); i++) {
+            char c = src.charAt(i);
+            if (Character.getType(c) != Character.FORMAT) {
+                return c;
+            }
+        }
+        return defChar;
     }
 
     /**


### PR DESCRIPTION
  [Backport] 8333462: Performance regression of new DecimalFormat() when compare to jdk11

  Summary: The DecimalFormat constructor calls DecimalFormatSymbols.findNonFormatChar(String,char) multiple times, and the lambda implementation of findNonFormatChar  is slow than plain loop implementation.

  Testing: All java.text.format jtreg.

  Reviewers: D-D-H, Yude Lin

  Issue: https://github.com/dragonwell-project/dragonwell21/issues/79