### PR TITLE
[Misc] Fast serialization

### DIFF
--- a/src/java.base/share/classes/java/io/ClassResolveCache.java
+++ b/src/java.base/share/classes/java/io/ClassResolveCache.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package java.io;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiFunction;
+
+/**
+ * This class holds the class resolve cache for FAST_SERIALIZATION feature.
+ */
+final class ClassResolveCache {
+    private final static Map<String, List<Entry>> nameToClasses = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the {@code Class} object associated with the class or
+     * interface with the given string name and classloader with cache.
+     *
+     * @param name        class name
+     * @param classLoader class loader
+     * @param load        method used to initial the cache
+     * @return the {@code Class} object for the class
+     * @throws ClassNotFoundException if the class cannot be located
+     */
+    static Class<?> forName(String name, ClassLoader classLoader,
+                            BiFunction<String, ClassLoader, Class<?>> load)
+            throws ClassNotFoundException {
+        List<Entry> entries = nameToClasses.get(name);
+        if (entries == null) {
+            entries = new CopyOnWriteArrayList<>();
+            nameToClasses.put(name, entries);
+        }
+
+        for (Entry entry : entries) {
+            Class<?> clazz = entry.clazz.get();
+            if (clazz == null) {
+                entries.remove(entry);
+            } else if (entry.classLoader.get() == classLoader) {
+                assert clazz.getName().equals(name);
+                return clazz;
+            }
+        }
+
+        Class<?> clazz = load.apply(name, classLoader);
+        if (clazz == null) {
+            throw new ClassNotFoundException(name);
+        }
+        entries.add(new Entry(classLoader, clazz));
+        return clazz;
+    }
+
+    private static final class Entry {
+        private final WeakReference<ClassLoader> classLoader;
+        private final WeakReference<Class<?>> clazz;
+
+        Entry(ClassLoader classLoader, Class<?> clazz) {
+            this.classLoader = new WeakReference<>(classLoader);
+            this.clazz = new WeakReference<>(clazz);
+        }
+    }
+}

--- a/src/java.base/share/classes/java/io/ClassResolveCache.java
+++ b/src/java.base/share/classes/java/io/ClassResolveCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -255,6 +255,16 @@ import sun.security.action.GetIntegerAction;
 public class ObjectInputStream
     extends InputStream implements ObjectInput, ObjectStreamConstants
 {
+    /**
+     * enable fast serialization:
+     * 1. Create a {@link ClassResolveCache} to reduce calls to {@link Class#forName(String)}
+     * 2. Cache {@link #latestUserDefinedLoader()}: The loader can be safely cached inside the
+     *    ObjectInputStream class, once custom {@link #readObject()} methods are invoked, the cache
+     *    will be invalid.
+     */
+    private static final boolean FAST_SERIALIZATION =
+            GetBooleanAction.privilegedGetProperty("com.alibaba.enableFastSerialization");
+
     /** handle value representing null */
     private static final int NULL_HANDLE = -1;
 
@@ -371,6 +381,11 @@ public class ObjectInputStream
      * True if the stream-specific filter has been set; initially false.
      */
     private boolean streamFilterSet;
+
+    /**
+     * {@link #latestUserDefinedLoader()} cache used by FAST_SERIALIZATION feature.
+     */
+    private ClassLoader latestUserDefinedLoaderCache;
 
     /**
      * Creates an ObjectInputStream that reads from the specified InputStream.
@@ -800,6 +815,19 @@ public class ObjectInputStream
         throws IOException, ClassNotFoundException
     {
         String name = desc.getName();
+        if (FAST_SERIALIZATION) {
+            if (latestUserDefinedLoaderCache == null) {
+                latestUserDefinedLoaderCache = latestUserDefinedLoader();
+            }
+            return ClassResolveCache.forName(name, latestUserDefinedLoaderCache,
+                    (className, loader) -> {
+                        try {
+                            return Class.forName(className, false, loader);
+                        } catch (ClassNotFoundException ex) {
+                            return primClasses.get(className);
+                        }
+                    });
+        }
         try {
             return Class.forName(name, false, latestUserDefinedLoader());
         } catch (ClassNotFoundException ex) {
@@ -2441,7 +2469,19 @@ public class ObjectInputStream
                         curContext = new SerialCallbackContext(obj, slotDesc);
 
                         bin.setBlockDataMode(true);
+                        ClassLoader currentLatestUserDefinedLoaderCache = null;
+                        if (FAST_SERIALIZATION) {
+                            ClassLoader classLoader = obj.getClass().getClassLoader();
+                            if (classLoader != null &&
+                                    classLoader != ClassLoader.getPlatformClassLoader()) {
+                                currentLatestUserDefinedLoaderCache = latestUserDefinedLoaderCache;
+                                latestUserDefinedLoaderCache = null;
+                            }
+                        }
                         slotDesc.invokeReadObject(obj, this);
+                        if (FAST_SERIALIZATION && currentLatestUserDefinedLoaderCache != null) {
+                            latestUserDefinedLoaderCache = currentLatestUserDefinedLoaderCache;
+                        }
                     } catch (ClassNotFoundException ex) {
                         /*
                          * In most cases, the handle table has already

--- a/test/jdk/java/io/ObjectInputStream/PeekInputStreamTest.java
+++ b/test/jdk/java/io/ObjectInputStream/PeekInputStreamTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +34,9 @@ import java.lang.reflect.Method;
  * @modules java.base/java.io:open
  * @summary verifies java.io.ObjectInputStream.PeekInputStream.skip works
  *          as intended
+ *
+ * @run main PeekInputStreamTest
+ * @run main/othervm -Dcom.alibaba.enableFastSerialization=true PeekInputStreamTest
  */
 public class PeekInputStreamTest {
 

--- a/test/jdk/java/io/ObjectInputStream/ResolveProxyClass.java
+++ b/test/jdk/java/io/ObjectInputStream/ResolveProxyClass.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +35,7 @@
  *
  * @build ResolveProxyClass
  * @run main ResolveProxyClass
+ * @run main/othervm -Dcom.alibaba.enableFastSerialization=true ResolveProxyClass
  */
 
 import java.io.*;

--- a/test/jdk/java/io/ObjectInputStream/ResolveProxyClass.java
+++ b/test/jdk/java/io/ObjectInputStream/ResolveProxyClass.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/io/ObjectInputStream/TestObjectStreamClass.java
+++ b/test/jdk/java/io/ObjectInputStream/TestObjectStreamClass.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +25,8 @@
 /* @test
  * @bug 8135043
  * @summary ObjectStreamClass.getField(String) too restrictive
+ * @run main TestObjectStreamClass
+ * @run main/othervm -Dcom.alibaba.enableFastSerialization=true TestObjectStreamClass
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/micro/com/alibaba/bench/java/io/ObjectInputStreamTest.java
+++ b/test/micro/com/alibaba/bench/java/io/ObjectInputStreamTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package com.alibaba.bench.java.io;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+@State(Scope.Benchmark)
+public class ObjectInputStreamTest {
+    private Object o;
+
+    @Setup
+    public void setup() {
+        List<Integer> nums = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            nums.add(ThreadLocalRandom.current().nextInt());
+        }
+        List<String> strings = new ArrayList<>();
+        byte[] ba = new byte[36];
+        for (int i = 0; i < 20; i++) {
+            ThreadLocalRandom.current().nextBytes(ba);
+            strings.add(Base64.getEncoder().encodeToString(ba));
+        }
+        HashMap<String, List<?>> m = new HashMap<>();
+        m.put("nums", nums);
+        m.put("strings", strings);
+        m.put("empty", Collections.emptyList());
+        o = m;
+    }
+
+    @Benchmark
+    public void io(Blackhole bh) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos);
+        oos.writeObject(o);
+        oos.close();
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()));
+        bh.consume(ois.readObject());
+    }
+}

--- a/test/micro/com/alibaba/bench/java/io/ObjectInputStreamTest.java
+++ b/test/micro/com/alibaba/bench/java/io/ObjectInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Summary:
Introduce fast serialization feature.
This feature can be enabled by -Dcom.alibaba.enableFastSerialization=true. Porting from https://github.com/dragonwell-project/dragonwell11/commit/bfdc9053ffbef1b062d6e5d4972f11b1e94cd4d6 and the origin author is lei.yul.

1. Create a ClassResolveCache to reduce calls to Class.forName(String)
2. Cache latestUserDefinedLoader(): The loader can be safely cached inside the ObjectInputStream class, once custom readObject() methods are invoked, the cache will be invalid.

For simple data objects, we can observe a 26% performance improvement. See com.alibaba.bench.java.io.ObjectInputStreamTest.

Reviewed-by: lei.yul, kuaiwei

Testing:  ObjectInputStream jtreg tests

Issue: https://github.com/dragonwell-project/dragonwell21/issues/76