### PR TITLE
[JIT] Backport changes to reduce nmethod size in code cache

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -78,86 +78,71 @@ unsigned int CodeBlob::allocation_size(CodeBuffer* cb, int header_size) {
   return size;
 }
 
-CodeBlob::CodeBlob(const char* name, CompilerType type, const CodeBlobLayout& layout, int frame_complete_offset, int frame_size, ImmutableOopMapSet* oop_maps, bool caller_must_gc_arguments, bool compiled) :
-  _code_begin(layout.code_begin()),
-  _code_end(layout.code_end()),
-  _content_begin(layout.content_begin()),
-  _data_end(layout.data_end()),
-  _relocation_begin(layout.relocation_begin()),
-  _relocation_end(layout.relocation_end()),
-  _oop_maps(oop_maps),
+CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, CompilerType type, CodeBuffer* cb, int size, uint16_t header_size,
+                   int16_t frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments) :
+  _oop_maps(nullptr), // will be set by set_oop_maps() call
   _name(name),
-  _size(layout.size()),
-  _header_size(layout.header_size()),
-  _frame_complete_offset(frame_complete_offset),
-  _data_offset(layout.data_offset()),
+  _size(size),
+  _relocation_size(align_up(cb->total_relocation_size(), oopSize)),
+  _content_offset(CodeBlob::align_code_offset(header_size + _relocation_size)),
+  _code_offset(_content_offset + cb->total_offset_of(cb->insts())),
+  _data_offset(_content_offset + align_up(cb->total_content_size(), oopSize)),
   _frame_size(frame_size),
+  S390_ONLY(_ctable_offset(0) COMMA)
+  _header_size(header_size),
+  _frame_complete_offset(frame_complete_offset),
+  _kind(kind),
   _caller_must_gc_arguments(caller_must_gc_arguments),
-  _is_compiled(compiled),
   _type(type)
 {
-  assert(is_aligned(layout.size(),            oopSize), "unaligned size");
-  assert(is_aligned(layout.header_size(),     oopSize), "unaligned size");
-  assert(is_aligned(layout.relocation_size(), oopSize), "unaligned size");
-  assert(layout.code_end() == layout.content_end(), "must be the same - see code_end()");
+  assert(is_aligned(_size,            oopSize), "unaligned size");
+  assert(is_aligned(header_size,      oopSize), "unaligned size");
+  assert(is_aligned(_relocation_size, oopSize), "unaligned size");
+  assert(_data_offset <= _size, "codeBlob is too small: %d > %d", _data_offset, _size);
+  assert(code_end() == content_end(), "must be the same - see code_end()");
 #ifdef COMPILER1
   // probably wrong for tiered
   assert(_frame_size >= -1, "must use frame size or -1 for runtime stubs");
 #endif // COMPILER1
-  S390_ONLY(_ctable_offset = 0;) // avoid uninitialized fields
-}
-
-CodeBlob::CodeBlob(const char* name, CompilerType type, const CodeBlobLayout& layout, CodeBuffer* cb /*UNUSED*/, int frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments, bool compiled) :
-  _code_begin(layout.code_begin()),
-  _code_end(layout.code_end()),
-  _content_begin(layout.content_begin()),
-  _data_end(layout.data_end()),
-  _relocation_begin(layout.relocation_begin()),
-  _relocation_end(layout.relocation_end()),
-  _name(name),
-  _size(layout.size()),
-  _header_size(layout.header_size()),
-  _frame_complete_offset(frame_complete_offset),
-  _data_offset(layout.data_offset()),
-  _frame_size(frame_size),
-  _caller_must_gc_arguments(caller_must_gc_arguments),
-  _is_compiled(compiled),
-  _type(type)
-{
-  assert(is_aligned(_size,        oopSize), "unaligned size");
-  assert(is_aligned(_header_size, oopSize), "unaligned size");
-  assert(_data_offset <= _size, "codeBlob is too small");
-  assert(layout.code_end() == layout.content_end(), "must be the same - see code_end()");
-
+ 
   set_oop_maps(oop_maps);
-#ifdef COMPILER1
-  // probably wrong for tiered
-  assert(_frame_size >= -1, "must use frame size or -1 for runtime stubs");
-#endif // COMPILER1
-  S390_ONLY(_ctable_offset = 0;) // avoid uninitialized fields
 }
 
-
-// Creates a simple CodeBlob. Sets up the size of the different regions.
-RuntimeBlob::RuntimeBlob(const char* name, int header_size, int size, int frame_complete, int locs_size)
-  : CodeBlob(name, compiler_none, CodeBlobLayout((address) this, size, header_size, locs_size, size), frame_complete, 0, nullptr, false /* caller_must_gc_arguments */)
+// Simple CodeBlob used for simple BufferBlob.
+CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t header_size) :
+  _oop_maps(nullptr),
+  _name(name),
+  _size(size),
+  _relocation_size(0),
+  _content_offset(CodeBlob::align_code_offset(header_size)),
+  _code_offset(_content_offset),
+  _data_offset(size),
+  _frame_size(0),
+  S390_ONLY(_ctable_offset(0) COMMA)
+  _header_size(header_size),
+  _frame_complete_offset(CodeOffsets::frame_never_safe),
+  _kind(kind),
+  _caller_must_gc_arguments(false),
+  _type(compiler_none)
 {
-  assert(is_aligned(locs_size, oopSize), "unaligned size");
+  assert(is_aligned(size,            oopSize), "unaligned size");
+  assert(is_aligned(header_size,     oopSize), "unaligned size");
 }
-
 
 // Creates a RuntimeBlob from a CodeBuffer
 // and copy code and relocation info.
 RuntimeBlob::RuntimeBlob(
   const char* name,
+  CodeBlobKind kind,
   CodeBuffer* cb,
-  int         header_size,
   int         size,
-  int         frame_complete,
+  uint16_t    header_size,
+  int16_t     frame_complete,
   int         frame_size,
   OopMapSet*  oop_maps,
   bool        caller_must_gc_arguments
-) : CodeBlob(name, compiler_none, CodeBlobLayout((address) this, size, header_size, cb), cb, frame_complete, frame_size, oop_maps, caller_must_gc_arguments) {
+) : CodeBlob(name, kind, compiler_none, cb, size, header_size, frame_complete, frame_size, oop_maps, caller_must_gc_arguments)
+{
   cb->copy_code_and_locs_to(this);
 }
 
@@ -245,8 +230,8 @@ void CodeBlob::print_code() {
 // Implementation of BufferBlob
 
 
-BufferBlob::BufferBlob(const char* name, int size)
-: RuntimeBlob(name, sizeof(BufferBlob), size, CodeOffsets::frame_never_safe, /*locs_size:*/ 0)
+BufferBlob::BufferBlob(const char* name, CodeBlobKind kind, int size)
+: RuntimeBlob(name, kind, size, sizeof(BufferBlob))
 {}
 
 BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
@@ -260,7 +245,7 @@ BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
   assert(name != nullptr, "must provide a name");
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) BufferBlob(name, size);
+    blob = new (size) BufferBlob(name, CodeBlobKind::Buffer, size);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -269,10 +254,11 @@ BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
 }
 
 
-BufferBlob::BufferBlob(const char* name, int size, CodeBuffer* cb)
-  : RuntimeBlob(name, cb, sizeof(BufferBlob), size, CodeOffsets::frame_never_safe, 0, nullptr)
+BufferBlob::BufferBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size)
+  : RuntimeBlob(name, kind, cb, size, sizeof(BufferBlob), CodeOffsets::frame_never_safe, 0, nullptr)
 {}
 
+// Used by gtest
 BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
 
@@ -281,7 +267,7 @@ BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
   assert(name != nullptr, "must provide a name");
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) BufferBlob(name, size, cb);
+    blob = new (size) BufferBlob(name, CodeBlobKind::Buffer, cb, size);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -302,7 +288,7 @@ void BufferBlob::free(BufferBlob *blob) {
 // Implementation of AdapterBlob
 
 AdapterBlob::AdapterBlob(int size, CodeBuffer* cb) :
-  BufferBlob("I2C/C2I adapters", size, cb) {
+  BufferBlob("I2C/C2I adapters", CodeBlobKind::Adapter, cb, size) {
   CodeCache::commit(this);
 }
 
@@ -334,7 +320,7 @@ void* VtableBlob::operator new(size_t s, unsigned size) throw() {
 }
 
 VtableBlob::VtableBlob(const char* name, int size) :
-  BufferBlob(name, size) {
+  BufferBlob(name, CodeBlobKind::Vtable, size) {
 }
 
 VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
@@ -400,18 +386,19 @@ RuntimeStub::RuntimeStub(
   const char* name,
   CodeBuffer* cb,
   int         size,
-  int         frame_complete,
+  int16_t     frame_complete,
   int         frame_size,
   OopMapSet*  oop_maps,
   bool        caller_must_gc_arguments
 )
-: RuntimeBlob(name, cb, sizeof(RuntimeStub), size, frame_complete, frame_size, oop_maps, caller_must_gc_arguments)
+: RuntimeBlob(name, CodeBlobKind::Runtime_Stub, cb, size, sizeof(RuntimeStub),
+              frame_complete, frame_size, oop_maps, caller_must_gc_arguments)
 {
 }
 
 RuntimeStub* RuntimeStub::new_runtime_stub(const char* stub_name,
                                            CodeBuffer* cb,
-                                           int frame_complete,
+                                           int16_t frame_complete,
                                            int frame_size,
                                            OopMapSet* oop_maps,
                                            bool caller_must_gc_arguments)
@@ -456,7 +443,8 @@ DeoptimizationBlob::DeoptimizationBlob(
   int         unpack_with_reexecution_offset,
   int         frame_size
 )
-: SingletonBlob("DeoptimizationBlob", cb, sizeof(DeoptimizationBlob), size, frame_size, oop_maps)
+: SingletonBlob("DeoptimizationBlob", CodeBlobKind::Deoptimization, cb,
+                size, sizeof(DeoptimizationBlob), frame_size, oop_maps)
 {
   _unpack_offset           = unpack_offset;
   _unpack_with_exception   = unpack_with_exception_offset;
@@ -505,7 +493,8 @@ UncommonTrapBlob::UncommonTrapBlob(
   OopMapSet*  oop_maps,
   int         frame_size
 )
-: SingletonBlob("UncommonTrapBlob", cb, sizeof(UncommonTrapBlob), size, frame_size, oop_maps)
+: SingletonBlob("UncommonTrapBlob", CodeBlobKind::Uncommon_Trap, cb,
+                size, sizeof(UncommonTrapBlob), frame_size, oop_maps)
 {}
 
 
@@ -541,7 +530,8 @@ ExceptionBlob::ExceptionBlob(
   OopMapSet*  oop_maps,
   int         frame_size
 )
-: SingletonBlob("ExceptionBlob", cb, sizeof(ExceptionBlob), size, frame_size, oop_maps)
+: SingletonBlob("ExceptionBlob", CodeBlobKind::Exception, cb,
+                size, sizeof(ExceptionBlob), frame_size, oop_maps)
 {}
 
 
@@ -576,7 +566,8 @@ SafepointBlob::SafepointBlob(
   OopMapSet*  oop_maps,
   int         frame_size
 )
-: SingletonBlob("SafepointBlob", cb, sizeof(SafepointBlob), size, frame_size, oop_maps)
+: SingletonBlob("SafepointBlob", CodeBlobKind::Safepoint, cb,
+                size, sizeof(SafepointBlob), frame_size, oop_maps)
 {}
 
 
@@ -736,7 +727,8 @@ void DeoptimizationBlob::print_value_on(outputStream* st) const {
 UpcallStub::UpcallStub(const char* name, CodeBuffer* cb, int size,
                        intptr_t exception_handler_offset,
                        jobject receiver, ByteSize frame_data_offset) :
-  RuntimeBlob(name, cb, sizeof(UpcallStub), size, CodeOffsets::frame_never_safe, 0 /* no frame size */,
+  RuntimeBlob(name, CodeBlobKind::Upcall, cb, size, sizeof(UpcallStub),
+              CodeOffsets::frame_never_safe, 0 /* no frame size */,
               /* oop maps = */ nullptr, /* caller must gc arguments = */ false),
   _exception_handler_offset(exception_handler_offset),
   _receiver(receiver),

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -75,10 +75,24 @@ enum class CodeBlobType {
 //     - instruction space
 //   - data space
 
+enum class CodeBlobKind : u1 {
+  None,
+  Nmethod,
+  Buffer,
+  Adapter,
+  Vtable,
+  MH_Adapter,
+  Runtime_Stub,
+  Deoptimization,
+  Exception,
+  Safepoint,
+  Uncommon_Trap,
+  Upcall,
+  Number_Of_Kinds
+};
 
-class CodeBlobLayout;
-class UpcallStub; // for as_upcall_stub()
-class RuntimeStub; // for as_runtime_stub()
+class UpcallStub;      // for as_upcall_stub()
+class RuntimeStub;     // for as_runtime_stub()
 class JavaFrameAnchor; // for UpcallStub::jfa_for_frame
 
 class CodeBlob {
@@ -89,44 +103,37 @@ class CodeBlob {
 protected:
 
   // order fields from large to small to minimize padding between fields
-  address    _code_begin;
-  address    _code_end;
-  address    _content_begin;                     // address to where content region begins (this includes consts, insts, stubs)
-                                                 // address    _content_end - not required, for all CodeBlobs _code_end == _content_end for now
-  address    _data_end;
-  address    _relocation_begin;
-  address    _relocation_end;
-
-  ImmutableOopMapSet* _oop_maps;                 // OopMap for this CodeBlob
-
+  ImmutableOopMapSet* _oop_maps;   // OopMap for this CodeBlob
   const char*         _name;
+
+  int        _size;                // total size of CodeBlob in bytes
+  int        _relocation_size;     // size of relocation
+  int        _content_offset;      // offset to where content region begins (this includes consts, insts, stubs)
+  int        _code_offset;         // offset to where instructions region begins (this includes insts, stubs)
+  int        _data_offset;         // offset to where data region begins
+  int        _frame_size;          // size of stack frame in words (NOT slots. On x64 these are 64bit words)
+
   S390_ONLY(int       _ctable_offset;)
+  uint16_t _header_size;           // size of header (depends on subclass)
+  int16_t  _frame_complete_offset; // instruction offsets in [0.._frame_complete_offset) have
+                                   // not finished setting up their frame. Beware of pc's in
+                                   // that range. There is a similar range(s) on returns
+                                   // which we don't detect.
 
-  int        _size;                              // total size of CodeBlob in bytes
-  int        _header_size;                       // size of header (depends on subclass)
-  int        _frame_complete_offset;             // instruction offsets in [0.._frame_complete_offset) have
-                                                 // not finished setting up their frame. Beware of pc's in
-                                                 // that range. There is a similar range(s) on returns
-                                                 // which we don't detect.
-  int        _data_offset;                       // offset to where data region begins
-  int        _frame_size;                        // size of stack frame in words (NOT slots. On x64 these are 64bit words)
-
+  CodeBlobKind        _kind;       // Kind of this code blob
   bool                _caller_must_gc_arguments;
-
-  bool                _is_compiled;
   const CompilerType  _type;                     // CompilerType
 
 #ifndef PRODUCT
   AsmRemarks _asm_remarks;
   DbgStrings _dbg_strings;
-#endif // not PRODUCT
+#endif
 
-  CodeBlob(const char* name, CompilerType type, const CodeBlobLayout& layout, int frame_complete_offset,
-           int frame_size, ImmutableOopMapSet* oop_maps,
-           bool caller_must_gc_arguments, bool compiled = false);
-  CodeBlob(const char* name, CompilerType type, const CodeBlobLayout& layout, CodeBuffer* cb, int frame_complete_offset,
-           int frame_size, OopMapSet* oop_maps,
-           bool caller_must_gc_arguments, bool compiled = false);
+  CodeBlob(const char* name, CodeBlobKind kind, CompilerType type, CodeBuffer* cb, int size, uint16_t header_size,
+           int16_t frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments);
+
+  // Simple CodeBlob used for simple BufferBlob.
+  CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t header_size);
 
   void operator delete(void* p) { }
 
@@ -146,19 +153,18 @@ public:
   virtual void purge(bool free_code_cache_data, bool unregister_nmethod);
 
   // Typing
-  virtual bool is_buffer_blob() const                 { return false; }
-  virtual bool is_nmethod() const                     { return false; }
-  virtual bool is_runtime_stub() const                { return false; }
-  virtual bool is_deoptimization_stub() const         { return false; }
-  virtual bool is_uncommon_trap_stub() const          { return false; }
-  virtual bool is_exception_stub() const              { return false; }
-  virtual bool is_safepoint_stub() const              { return false; }
-  virtual bool is_adapter_blob() const                { return false; }
-  virtual bool is_vtable_blob() const                 { return false; }
-  virtual bool is_method_handles_adapter_blob() const { return false; }
-  virtual bool is_upcall_stub() const                 { return false; }
-  bool is_compiled() const                            { return _is_compiled; }
-  const bool* is_compiled_addr() const                { return &_is_compiled; }
+  bool is_nmethod() const                     { return _kind == CodeBlobKind::Nmethod; }
+  bool is_buffer_blob() const                 { return _kind == CodeBlobKind::Buffer; }
+  bool is_runtime_stub() const                { return _kind == CodeBlobKind::Runtime_Stub; }
+  bool is_deoptimization_stub() const         { return _kind == CodeBlobKind::Deoptimization; }
+  bool is_uncommon_trap_stub() const          { return _kind == CodeBlobKind::Uncommon_Trap; }
+  bool is_exception_stub() const              { return _kind == CodeBlobKind::Exception; }
+  bool is_safepoint_stub() const              { return _kind == CodeBlobKind::Safepoint; }
+  bool is_adapter_blob() const                { return _kind == CodeBlobKind::Adapter; }
+  bool is_vtable_blob() const                 { return _kind == CodeBlobKind::Vtable; }
+  bool is_method_handles_adapter_blob() const { return _kind == CodeBlobKind::MH_Adapter; }
+  bool is_upcall_stub() const                 { return _kind == CodeBlobKind::Upcall; }
+  bool is_compiled() const                    { return _kind == CodeBlobKind::Nmethod || _type != compiler_none; }
 
   inline bool is_compiled_by_c1() const    { return _type == compiler_c1; };
   inline bool is_compiled_by_c2() const    { return _type == compiler_c2; };
@@ -176,14 +182,22 @@ public:
   RuntimeStub* as_runtime_stub() const         { assert(is_runtime_stub(), "must be runtime blob"); return (RuntimeStub*) this; }
 
   // Boundaries
-  address header_begin() const        { return (address) this; }
-  relocInfo* relocation_begin() const { return (relocInfo*) _relocation_begin; };
-  relocInfo* relocation_end() const   { return (relocInfo*) _relocation_end; }
-  address content_begin() const       { return _content_begin; }
-  address content_end() const         { return _code_end; } // _code_end == _content_end is true for all types of blobs for now, it is also checked in the constructor
-  address code_begin() const          { return _code_begin;    }
-  address code_end() const            { return _code_end; }
-  address data_end() const            { return _data_end;      }
+  address    header_begin() const             { return (address)    this; }
+  address    header_end() const               { return ((address)   this) + _header_size; }
+  relocInfo* relocation_begin() const         { return (relocInfo*) header_end(); }
+  relocInfo* relocation_end() const           { return (relocInfo*)(header_end()   + _relocation_size); }
+  address    content_begin() const            { return (address)    header_begin() + _content_offset; }
+  address    content_end() const              { return (address)    header_begin() + _data_offset; }
+  address    code_begin() const               { return (address)    header_begin() + _code_offset; }
+  // code_end == content_end is true for all types of blobs for now, it is also checked in the constructor
+  address    code_end() const                 { return (address)    header_begin() + _data_offset; }
+  address    data_begin() const               { return (address)    header_begin() + _data_offset; }
+  address    data_end() const                 { return (address)    header_begin() + _size; }
+
+  // Offsets
+  int content_offset() const                  { return _content_offset; }
+  int code_offset() const                     { return _code_offset; }
+  int data_offset() const                     { return _data_offset; }
 
   // This field holds the beginning of the const section in the old code buffer.
   // It is needed to fix relocations of pc-relative loads when resizing the
@@ -201,8 +215,6 @@ public:
   void adjust_size(size_t used) {
     _size = (int)used;
     _data_offset = (int)used;
-    _code_end = (address)this + used;
-    _data_end = (address)this + used;
   }
 
   // Containment
@@ -260,97 +272,8 @@ public:
 #endif
 };
 
-class CodeBlobLayout : public StackObj {
-private:
-  int _size;
-  int _header_size;
-  int _relocation_size;
-  int _content_offset;
-  int _code_offset;
-  int _data_offset;
-  address _code_begin;
-  address _code_end;
-  address _content_begin;
-  address _content_end;
-  address _data_end;
-  address _relocation_begin;
-  address _relocation_end;
-
-public:
-  CodeBlobLayout(address code_begin, address code_end, address content_begin, address content_end, address data_end, address relocation_begin, address relocation_end) :
-    _size(0),
-    _header_size(0),
-    _relocation_size(0),
-    _content_offset(0),
-    _code_offset(0),
-    _data_offset(0),
-    _code_begin(code_begin),
-    _code_end(code_end),
-    _content_begin(content_begin),
-    _content_end(content_end),
-    _data_end(data_end),
-    _relocation_begin(relocation_begin),
-    _relocation_end(relocation_end)
-  {
-  }
-
-  CodeBlobLayout(const address start, int size, int header_size, int relocation_size, int data_offset) :
-    _size(size),
-    _header_size(header_size),
-    _relocation_size(relocation_size),
-    _content_offset(CodeBlob::align_code_offset(_header_size + _relocation_size)),
-    _code_offset(_content_offset),
-    _data_offset(data_offset)
-  {
-    assert(is_aligned(_relocation_size, oopSize), "unaligned size");
-
-    _code_begin = (address) start + _code_offset;
-    _code_end = (address) start + _data_offset;
-
-    _content_begin = (address) start + _content_offset;
-    _content_end = (address) start + _data_offset;
-
-    _data_end = (address) start + _size;
-    _relocation_begin = (address) start + _header_size;
-    _relocation_end = _relocation_begin + _relocation_size;
-  }
-
-  CodeBlobLayout(const address start, int size, int header_size, const CodeBuffer* cb) :
-    _size(size),
-    _header_size(header_size),
-    _relocation_size(align_up(cb->total_relocation_size(), oopSize)),
-    _content_offset(CodeBlob::align_code_offset(_header_size + _relocation_size)),
-    _code_offset(_content_offset + cb->total_offset_of(cb->insts())),
-    _data_offset(_content_offset + align_up(cb->total_content_size(), oopSize))
-  {
-    assert(is_aligned(_relocation_size, oopSize), "unaligned size");
-
-    _code_begin = (address) start + _code_offset;
-    _code_end = (address) start + _data_offset;
-
-    _content_begin = (address) start + _content_offset;
-    _content_end = (address) start + _data_offset;
-
-    _data_end = (address) start + _size;
-    _relocation_begin = (address) start + _header_size;
-    _relocation_end = _relocation_begin + _relocation_size;
-  }
-
-  int size() const { return _size; }
-  int header_size() const { return _header_size; }
-  int relocation_size() const { return _relocation_size; }
-  int content_offset() const { return _content_offset; }
-  int code_offset() const { return _code_offset; }
-  int data_offset() const { return _data_offset; }
-  address code_begin() const { return _code_begin; }
-  address code_end() const { return _code_end; }
-  address data_end() const { return _data_end; }
-  address relocation_begin() const { return _relocation_begin; }
-  address relocation_end() const { return _relocation_end; }
-  address content_begin() const { return _content_begin; }
-  address content_end() const { return _content_end; }
-};
-
+//----------------------------------------------------------------------------------------------------
+// RuntimeBlob: used for non-compiled method code (adapters, stubs, blobs)
 
 class RuntimeBlob : public CodeBlob {
   friend class VMStructs;
@@ -358,17 +281,20 @@ class RuntimeBlob : public CodeBlob {
 
   // Creation
   // a) simple CodeBlob
-  // frame_complete is the offset from the beginning of the instructions
-  // to where the frame setup (from stackwalk viewpoint) is complete.
-  RuntimeBlob(const char* name, int header_size, int size, int frame_complete, int locs_size);
+  RuntimeBlob(const char* name, CodeBlobKind kind, int size, uint16_t header_size)
+    : CodeBlob(name, kind, size, header_size)
+  {}
 
   // b) full CodeBlob
+  // frame_complete is the offset from the beginning of the instructions
+  // to where the frame setup (from stackwalk viewpoint) is complete.
   RuntimeBlob(
     const char* name,
+    CodeBlobKind kind,
     CodeBuffer* cb,
-    int         header_size,
     int         size,
-    int         frame_complete,
+    uint16_t    header_size,
+    int16_t     frame_complete,
     int         frame_size,
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments = false
@@ -403,8 +329,8 @@ class BufferBlob: public RuntimeBlob {
 
  private:
   // Creation support
-  BufferBlob(const char* name, int size);
-  BufferBlob(const char* name, int size, CodeBuffer* cb);
+  BufferBlob(const char* name, CodeBlobKind kind, int size);
+  BufferBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size);
 
   void* operator new(size_t s, unsigned size) throw();
 
@@ -414,9 +340,6 @@ class BufferBlob: public RuntimeBlob {
   static BufferBlob* create(const char* name, CodeBuffer* cb);
 
   static void free(BufferBlob* buf);
-
-  // Typing
-  virtual bool is_buffer_blob() const            { return true; }
 
   // GC/Verification support
   void preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f)  { /* nothing to do */ }
@@ -437,9 +360,6 @@ private:
 public:
   // Creation
   static AdapterBlob* create(CodeBuffer* cb);
-
-  // Typing
-  virtual bool is_adapter_blob() const { return true; }
 };
 
 //---------------------------------------------------------------------------------------------------
@@ -452,9 +372,6 @@ private:
 public:
   // Creation
   static VtableBlob* create(const char* name, int buffer_size);
-
-  // Typing
-  virtual bool is_vtable_blob() const { return true; }
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -462,14 +379,11 @@ public:
 
 class MethodHandlesAdapterBlob: public BufferBlob {
 private:
-  MethodHandlesAdapterBlob(int size): BufferBlob("MethodHandles adapters", size) {}
+  MethodHandlesAdapterBlob(int size): BufferBlob("MethodHandles adapters", CodeBlobKind::MH_Adapter, size) {}
 
 public:
   // Creation
   static MethodHandlesAdapterBlob* create(int buffer_size);
-
-  // Typing
-  virtual bool is_method_handles_adapter_blob() const { return true; }
 };
 
 
@@ -484,7 +398,7 @@ class RuntimeStub: public RuntimeBlob {
     const char* name,
     CodeBuffer* cb,
     int         size,
-    int         frame_complete,
+    int16_t     frame_complete,
     int         frame_size,
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments
@@ -497,16 +411,13 @@ class RuntimeStub: public RuntimeBlob {
   static RuntimeStub* new_runtime_stub(
     const char* stub_name,
     CodeBuffer* cb,
-    int         frame_complete,
+    int16_t     frame_complete,
     int         frame_size,
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments
   );
 
   static void free(RuntimeStub* stub) { RuntimeBlob::free(stub); }
-
-  // Typing
-  bool is_runtime_stub() const                   { return true; }
 
   address entry_point() const                    { return code_begin(); }
 
@@ -530,14 +441,15 @@ class SingletonBlob: public RuntimeBlob {
 
  public:
    SingletonBlob(
-     const char* name,
-     CodeBuffer* cb,
-     int         header_size,
-     int         size,
-     int         frame_size,
-     OopMapSet*  oop_maps
+     const char*  name,
+     CodeBlobKind kind,
+     CodeBuffer*  cb,
+     int          size,
+     uint16_t     header_size,
+     int          frame_size,
+     OopMapSet*   oop_maps
    )
-   : RuntimeBlob(name, cb, header_size, size, CodeOffsets::frame_never_safe, frame_size, oop_maps)
+   : RuntimeBlob(name, kind, cb, size, header_size, CodeOffsets::frame_never_safe, frame_size, oop_maps)
   {};
 
   address entry_point()                          { return code_begin(); }
@@ -590,9 +502,6 @@ class DeoptimizationBlob: public SingletonBlob {
     int         unpack_with_reexecution_offset,
     int         frame_size
   );
-
-  // Typing
-  bool is_deoptimization_stub() const { return true; }
 
   // GC for args
   void preserve_callee_argument_oops(frame fr, const RegisterMap *reg_map, OopClosure* f) { /* Nothing to do */ }
@@ -658,9 +567,6 @@ class UncommonTrapBlob: public SingletonBlob {
 
   // GC for args
   void preserve_callee_argument_oops(frame fr, const RegisterMap *reg_map, OopClosure* f)  { /* nothing to do */ }
-
-  // Typing
-  bool is_uncommon_trap_stub() const             { return true; }
 };
 
 
@@ -688,9 +594,6 @@ class ExceptionBlob: public SingletonBlob {
 
   // GC for args
   void preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f)  { /* nothing to do */ }
-
-  // Typing
-  bool is_exception_stub() const                 { return true; }
 };
 #endif // COMPILER2
 
@@ -719,9 +622,6 @@ class SafepointBlob: public SingletonBlob {
 
   // GC for args
   void preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f)  { /* nothing to do */ }
-
-  // Typing
-  bool is_safepoint_stub() const                 { return true; }
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -763,9 +663,6 @@ class UpcallStub: public RuntimeBlob {
   jobject receiver() { return _receiver; }
 
   JavaFrameAnchor* jfa_for_frame(const frame& frame) const;
-
-  // Typing
-  virtual bool is_upcall_stub() const override { return true; }
 
   // GC/Verification support
   void oops_do(OopClosure* f, const frame& frame);

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -50,23 +50,11 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/sharedRuntime.hpp"
 
-CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType type, const CodeBlobLayout& layout,
-                               int frame_complete_offset, int frame_size, ImmutableOopMapSet* oop_maps,
-                               bool caller_must_gc_arguments, bool compiled)
-  : CodeBlob(name, type, layout, frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments, compiled),
-    _deoptimization_status(not_marked),
-    _deoptimization_generation(0),
-    _method(method),
-    _gc_data(nullptr)
-{
-  init_defaults();
-}
-
 CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType type, int size,
                                int header_size, CodeBuffer* cb, int frame_complete_offset, int frame_size,
-                               OopMapSet* oop_maps, bool caller_must_gc_arguments, bool compiled)
-  : CodeBlob(name, type, CodeBlobLayout((address) this, size, header_size, cb), cb,
-             frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments, compiled),
+                               OopMapSet* oop_maps, bool caller_must_gc_arguments)
+  : CodeBlob(name, CodeBlobKind::Nmethod, type, cb, size, header_size,
+             frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments),
     _deoptimization_status(not_marked),
     _deoptimization_generation(0),
     _method(method),

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -182,8 +182,7 @@ private:
   }
 
 protected:
-  CompiledMethod(Method* method, const char* name, CompilerType type, const CodeBlobLayout& layout, int frame_complete_offset, int frame_size, ImmutableOopMapSet* oop_maps, bool caller_must_gc_arguments, bool compiled);
-  CompiledMethod(Method* method, const char* name, CompilerType type, int size, int header_size, CodeBuffer* cb, int frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments, bool compiled);
+  CompiledMethod(Method* method, const char* name, CompilerType type, int size, int header_size, CodeBuffer* cb, int frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments);
 
 public:
   // Only used by unit test.

--- a/src/hotspot/share/code/debugInfoRec.cpp
+++ b/src/hotspot/share/code/debugInfoRec.cpp
@@ -244,14 +244,11 @@ static
 struct dir_stats_struct {
   int chunks_queried;
   int chunks_shared;
-  int chunks_reshared;
   int chunks_elided;
 
   void print() {
-    tty->print_cr("Debug Data Chunks: %d, shared %d+%d, non-SP's elided %d",
-                  chunks_queried,
-                  chunks_shared, chunks_reshared,
-                  chunks_elided);
+    tty->print_cr("Debug Data Chunks: %d, shared %d, non-SP's elided %d",
+                  chunks_queried, chunks_shared, chunks_elided);
   }
 } dir_stats;
 #endif //PRODUCT

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,9 +387,7 @@ void Dependencies::copy_to(nmethod* nm) {
   address beg = nm->dependencies_begin();
   address end = nm->dependencies_end();
   guarantee(end - beg >= (ptrdiff_t) size_in_bytes(), "bad sizing");
-  Copy::disjoint_words((HeapWord*) content_bytes(),
-                       (HeapWord*) beg,
-                       size_in_bytes() / sizeof(HeapWord));
+  (void)memcpy(beg, content_bytes(), size_in_bytes());
   assert(size_in_bytes() % sizeof(HeapWord) == 0, "copy by words");
 }
 

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ inline bool is_compile(int comp_level) {
 
 
 // States of Restricted Transactional Memory usage.
-enum RTMState {
+enum RTMState: u1 {
   NoRTM      = 0x2, // Don't use RTM
   UseRTM     = 0x1, // Use RTM
   ProfileRTM = 0x0  // Use RTM with abort ratio calculation

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -281,7 +281,7 @@
   nonstatic_field(MethodData,                  _backedge_mask,                                int)                                   \
   nonstatic_field(MethodData,                  _jvmci_ir_size,                                int)                                   \
                                                                                                                                      \
-  nonstatic_field(nmethod,                     _verified_entry_point,                         address)                               \
+  nonstatic_field(nmethod,                     _verified_entry_offset,                        u2)                                    \
   nonstatic_field(nmethod,                     _comp_level,                                   CompLevel)                             \
                                                                                                                                      \
   nonstatic_field(ObjArrayKlass,               _element_klass,                                Klass*)                                \

--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -38,8 +38,8 @@ class HeapBlock {
 
  public:
   struct Header {
-    size_t  _length;                             // the length in segments
-    bool    _used;                               // Used bit
+    uint32_t  _length;                           // the length in segments
+    bool      _used;                             // Used bit
   };
 
  protected:
@@ -51,9 +51,11 @@ class HeapBlock {
 
  public:
   // Initialization
-  void initialize(size_t length)                 { _header._length = length; set_used(); }
+  void initialize(size_t length)                 { set_length(length); set_used(); }
   // Merging/splitting
-  void set_length(size_t length)                 { _header._length = length; }
+  void set_length(size_t length)                 {
+    _header._length = checked_cast<uint32_t>(length);
+  }
 
   // Accessors
   void* allocated_space() const                  { return (void*)(this + 1); }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1591,7 +1591,7 @@ CodeBlob* WhiteBox::allocate_code_blob(int size, CodeBlobType blob_type) {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
     blob = (BufferBlob*) CodeCache::allocate(full_size, blob_type);
     if (blob != nullptr) {
-      ::new (blob) BufferBlob("WB::DummyBlob", full_size);
+      ::new (blob) BufferBlob("WB::DummyBlob", CodeBlobKind::Buffer, full_size);
     }
   }
   // Track memory usage statistic after releasing CodeCache_lock

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -501,7 +501,7 @@
   nonstatic_field(CodeHeap,                    _segmap,                                       VirtualSpace)                          \
   nonstatic_field(CodeHeap,                    _log2_segment_size,                            int)                                   \
   nonstatic_field(HeapBlock,                   _header,                                       HeapBlock::Header)                     \
-  nonstatic_field(HeapBlock::Header,           _length,                                       size_t)                                \
+  nonstatic_field(HeapBlock::Header,           _length,                                       uint32_t)                              \
   nonstatic_field(HeapBlock::Header,           _used,                                         bool)                                  \
                                                                                                                                      \
   /**********************************/                                                                                               \
@@ -612,19 +612,18 @@
                                                                                                                                      \
   nonstatic_field(CodeBlob,                 _name,                                   const char*)                                    \
   nonstatic_field(CodeBlob,                 _size,                                   int)                                            \
-  nonstatic_field(CodeBlob,                 _header_size,                            int)                                            \
-  nonstatic_field(CodeBlob,                 _frame_complete_offset,                  int)                                            \
+  nonstatic_field(CodeBlob,                 _header_size,                                  u2)                                             \
+  nonstatic_field(CodeBlob,                 _relocation_size,                            int)                                            \
+  nonstatic_field(CodeBlob,                 _content_offset,                            int)                                            \
+  nonstatic_field(CodeBlob,                 _code_offset,                            int)                                            \
+  nonstatic_field(CodeBlob,                 _frame_complete_offset,                        int16_t)                                        \
   nonstatic_field(CodeBlob,                 _data_offset,                            int)                                            \
   nonstatic_field(CodeBlob,                 _frame_size,                             int)                                            \
   nonstatic_field(CodeBlob,                 _oop_maps,                               ImmutableOopMapSet*)                            \
-  nonstatic_field(CodeBlob,                 _code_begin,                             address)                                        \
-  nonstatic_field(CodeBlob,                 _code_end,                               address)                                        \
-  nonstatic_field(CodeBlob,                 _content_begin,                          address)                                        \
-  nonstatic_field(CodeBlob,                 _data_end,                               address)                                        \
+  nonstatic_field(CodeBlob,                 _caller_must_gc_arguments,                     bool)                                  \
                                                                                                                                      \
   nonstatic_field(DeoptimizationBlob,          _unpack_offset,                                int)                                   \
                                                                                                                                      \
-  nonstatic_field(RuntimeStub,                 _caller_must_gc_arguments,                     bool)                                  \
                                                                                                                                      \
   /********************************************************/                                                                         \
   /* CompiledMethod (NOTE: incomplete, but only a little) */                                                                         \
@@ -646,17 +645,16 @@
   nonstatic_field(nmethod,                     _exception_offset,                             int)                                   \
   nonstatic_field(nmethod,                     _orig_pc_offset,                               int)                                   \
   nonstatic_field(nmethod,                     _stub_offset,                                  int)                                   \
-  nonstatic_field(nmethod,                     _consts_offset,                                int)                                   \
-  nonstatic_field(nmethod,                     _oops_offset,                                  int)                                   \
-  nonstatic_field(nmethod,                     _metadata_offset,                              int)                                   \
-  nonstatic_field(nmethod,                     _scopes_pcs_offset,                            int)                                   \
-  nonstatic_field(nmethod,                     _dependencies_offset,                          int)                                   \
-  nonstatic_field(nmethod,                     _handler_table_offset,                         int)                                   \
-  nonstatic_field(nmethod,                     _nul_chk_table_offset,                         int)                                   \
-  nonstatic_field(nmethod,                     _nmethod_end_offset,                           int)                                   \
-  nonstatic_field(nmethod,                     _entry_point,                                  address)                               \
-  nonstatic_field(nmethod,                     _verified_entry_point,                         address)                               \
+  nonstatic_field(nmethod,                     _metadata_offset,                              u2)                                    \
+  nonstatic_field(nmethod,                     _scopes_pcs_offset,                            int)                                    \
+  nonstatic_field(nmethod,                     _scopes_data_offset,                           int)                                   \
+  nonstatic_field(nmethod,                     _handler_table_offset,                         u2)                                    \
+  nonstatic_field(nmethod,                     _nul_chk_table_offset,                         u2)                                    \
+  nonstatic_field(nmethod,                     _entry_offset,                                 u2)                                    \
+  nonstatic_field(nmethod,                     _verified_entry_offset,                        u2)                                    \
   nonstatic_field(nmethod,                     _osr_entry_point,                              address)                               \
+  nonstatic_field(nmethod,                     _immutable_data,                               address)                               \
+  nonstatic_field(nmethod,                     _immutable_data_size,                          int)                                   \
   nonstatic_field(nmethod,                     _compile_id,                                   int)                                   \
   nonstatic_field(nmethod,                     _comp_level,                                   CompLevel)                             \
                                                                                                                                      \
@@ -1199,6 +1197,7 @@
   declare_integer_type(ssize_t)                                           \
   declare_integer_type(intx)                                              \
   declare_integer_type(intptr_t)                                          \
+  declare_integer_type(int16_t)                                           \
   declare_integer_type(int64_t)                                           \
   declare_unsigned_integer_type(uintx)                                    \
   declare_unsigned_integer_type(uintptr_t)                                \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
@@ -25,10 +25,12 @@ package sun.jvm.hotspot.code;
 import sun.jvm.hotspot.compiler.ImmutableOopMap;
 import sun.jvm.hotspot.compiler.ImmutableOopMapSet;
 import sun.jvm.hotspot.debugger.Address;
+import sun.jvm.hotspot.oops.CIntField;
 import sun.jvm.hotspot.runtime.VM;
 import sun.jvm.hotspot.runtime.VMObject;
 import sun.jvm.hotspot.types.AddressField;
 import sun.jvm.hotspot.types.CIntegerField;
+import sun.jvm.hotspot.types.JShortField;
 import sun.jvm.hotspot.types.Type;
 import sun.jvm.hotspot.types.TypeDataBase;
 import sun.jvm.hotspot.utilities.Assert;
@@ -41,12 +43,11 @@ import sun.jvm.hotspot.utilities.Observer;
 public class CodeBlob extends VMObject {
   private static AddressField nameField;
   private static CIntegerField sizeField;
-  private static CIntegerField headerSizeField;
-  private static AddressField  contentBeginField;
-  private static AddressField  codeBeginField;
-  private static AddressField  codeEndField;
-  private static AddressField  dataEndField;
-  private static CIntegerField frameCompleteOffsetField;
+  private static CIntegerField relocationSizeField;
+  private static CIntField     headerSizeField;
+  private static CIntegerField contentOffsetField;
+  private static CIntegerField codeOffsetField;
+  private static CIntField     frameCompleteOffsetField;
   private static CIntegerField dataOffsetField;
   private static CIntegerField frameSizeField;
   private static AddressField  oopMapsField;
@@ -62,12 +63,11 @@ public class CodeBlob extends VMObject {
 
     nameField                = type.getAddressField("_name");
     sizeField                = type.getCIntegerField("_size");
-    headerSizeField          = type.getCIntegerField("_header_size");
-    frameCompleteOffsetField = type.getCIntegerField("_frame_complete_offset");
-    contentBeginField        = type.getAddressField("_content_begin");
-    codeBeginField           = type.getAddressField("_code_begin");
-    codeEndField             = type.getAddressField("_code_end");
-    dataEndField             = type.getAddressField("_data_end");
+    relocationSizeField      = type.getCIntegerField("_relocation_size");
+    headerSizeField          = new CIntField(type.getCIntegerField("_header_size"), 0);
+    contentOffsetField       = type.getCIntegerField("_content_offset");
+    codeOffsetField          = type.getCIntegerField("_code_offset");
+    frameCompleteOffsetField = new CIntField(type.getCIntegerField("_frame_complete_offset"), 0);
     dataOffsetField          = type.getCIntegerField("_data_offset");
     frameSizeField           = type.getCIntegerField("_frame_size");
     oopMapsField             = type.getAddressField("_oop_maps");
@@ -90,17 +90,22 @@ public class CodeBlob extends VMObject {
 
   public Address headerEnd() { return getAddress().addOffsetTo(getHeaderSize()); }
 
-  public Address contentBegin() { return contentBeginField.getValue(addr); }
+  public Address contentBegin()   { return headerBegin().addOffsetTo(getContentOffset()); }
 
   public Address contentEnd() { return headerBegin().addOffsetTo(getDataOffset()); }
 
-  public Address codeBegin() { return codeBeginField.getValue(addr); }
+  public Address codeBegin()      { return headerBegin().addOffsetTo(getCodeOffset()); }
 
-  public Address codeEnd() { return codeEndField.getValue(addr); }
+  public Address codeEnd()        { return headerBegin().addOffsetTo(getDataOffset()); }
 
   public Address dataBegin() { return headerBegin().addOffsetTo(getDataOffset()); }
 
-  public Address dataEnd() { return dataEndField.getValue(addr); }
+  public Address dataEnd()        { return headerBegin().addOffsetTo(getSize()); }
+
+  // Offsets
+  public int getContentOffset()   { return (int) contentOffsetField.getValue(addr); }
+
+  public int getCodeOffset()      { return (int) codeOffsetField.getValue(addr); }
 
   public long getFrameCompleteOffset() { return frameCompleteOffsetField.getValue(addr); }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
@@ -40,30 +40,30 @@ public class NMethod extends CompiledMethod {
   private static CIntegerField entryBCIField;
   /** To support simple linked-list chaining of nmethods */
   private static AddressField  osrLinkField;
+  private static AddressField  immutableDataField;
+  private static CIntegerField immutableDataSizeField;
 
   /** Offsets for different nmethod parts */
   private static CIntegerField exceptionOffsetField;
   private static CIntegerField origPCOffsetField;
   private static CIntegerField stubOffsetField;
-  private static CIntegerField oopsOffsetField;
-  private static CIntegerField metadataOffsetField;
+  private static CIntField     metadataOffsetField;
+  private static CIntField     handlerTableOffsetField;
+  private static CIntField     nulChkTableOffsetField;
   private static CIntegerField scopesPCsOffsetField;
-  private static CIntegerField dependenciesOffsetField;
-  private static CIntegerField handlerTableOffsetField;
-  private static CIntegerField nulChkTableOffsetField;
-  private static CIntegerField nmethodEndOffsetField;
+  private static CIntegerField scopesDataOffsetField;
 
   /** Offsets for entry points */
   /** Entry point with class check */
-  private static AddressField  entryPointField;
+  private static CIntField  entryOffsetField;
   /** Entry point without class check */
-  private static AddressField  verifiedEntryPointField;
+  private static CIntField  verifiedEntryOffsetField;
   /** Entry point for on stack replacement */
   private static AddressField  osrEntryPointField;
 
   // FIXME: add access to flags (how?)
 
-  private static CIntegerField compLevelField;
+  private static CIntField compLevelField;
 
   static {
     VM.registerVMInitializedObserver(new Observer() {
@@ -78,21 +78,21 @@ public class NMethod extends CompiledMethod {
 
     entryBCIField               = type.getCIntegerField("_entry_bci");
     osrLinkField                = type.getAddressField("_osr_link");
+    immutableDataField          = type.getAddressField("_immutable_data");
+    immutableDataSizeField      = type.getCIntegerField("_immutable_data_size");
 
     exceptionOffsetField        = type.getCIntegerField("_exception_offset");
     origPCOffsetField           = type.getCIntegerField("_orig_pc_offset");
     stubOffsetField             = type.getCIntegerField("_stub_offset");
-    oopsOffsetField             = type.getCIntegerField("_oops_offset");
-    metadataOffsetField         = type.getCIntegerField("_metadata_offset");
+    metadataOffsetField         = new CIntField(type.getCIntegerField("_metadata_offset"), 0);
     scopesPCsOffsetField        = type.getCIntegerField("_scopes_pcs_offset");
-    dependenciesOffsetField     = type.getCIntegerField("_dependencies_offset");
-    handlerTableOffsetField     = type.getCIntegerField("_handler_table_offset");
-    nulChkTableOffsetField      = type.getCIntegerField("_nul_chk_table_offset");
-    nmethodEndOffsetField       = type.getCIntegerField("_nmethod_end_offset");
-    entryPointField             = type.getAddressField("_entry_point");
-    verifiedEntryPointField     = type.getAddressField("_verified_entry_point");
+    scopesDataOffsetField       = type.getCIntegerField("_scopes_data_offset");
+    handlerTableOffsetField     = new CIntField(type.getCIntegerField("_handler_table_offset"), 0);
+    nulChkTableOffsetField      = new CIntField(type.getCIntegerField("_nul_chk_table_offset"), 0);
+    entryOffsetField            = new CIntField(type.getCIntegerField("_entry_offset"), 0);
+    verifiedEntryOffsetField    = new CIntField(type.getCIntegerField("_verified_entry_offset"), 0);
     osrEntryPointField          = type.getAddressField("_osr_entry_point");
-    compLevelField              = type.getCIntegerField("_comp_level");
+    compLevelField              = new CIntField(type.getCIntegerField("_comp_level"), 0);
     pcDescSize = db.lookupType("PcDesc").getSize();
   }
 
@@ -113,26 +113,32 @@ public class NMethod extends CompiledMethod {
 
   /** Boundaries for different parts */
   public Address constantsBegin()       { return contentBegin();                                     }
-  public Address constantsEnd()         { return getEntryPoint();                                    }
+  public Address constantsEnd()         { return codeBegin();                                        }
   public Address instsBegin()           { return codeBegin();                                        }
   public Address instsEnd()             { return headerBegin().addOffsetTo(getStubOffset());         }
   public Address exceptionBegin()       { return headerBegin().addOffsetTo(getExceptionOffset());    }
   public Address stubBegin()            { return headerBegin().addOffsetTo(getStubOffset());         }
-  public Address stubEnd()              { return headerBegin().addOffsetTo(getOopsOffset());         }
-  public Address oopsBegin()            { return headerBegin().addOffsetTo(getOopsOffset());         }
-  public Address oopsEnd()              { return headerBegin().addOffsetTo(getMetadataOffset());     }
-  public Address metadataBegin()        { return headerBegin().addOffsetTo(getMetadataOffset());     }
-  public Address metadataEnd()          { return scopesDataBegin();                                  }
-  public Address scopesDataEnd()        { return headerBegin().addOffsetTo(getScopesPCsOffset());    }
-  public Address scopesPCsBegin()       { return headerBegin().addOffsetTo(getScopesPCsOffset());    }
-  public Address scopesPCsEnd()         { return headerBegin().addOffsetTo(getDependenciesOffset()); }
-  public Address dependenciesBegin()    { return headerBegin().addOffsetTo(getDependenciesOffset()); }
-  public Address dependenciesEnd()      { return headerBegin().addOffsetTo(getHandlerTableOffset()); }
-  public Address handlerTableBegin()    { return headerBegin().addOffsetTo(getHandlerTableOffset()); }
-  public Address handlerTableEnd()      { return headerBegin().addOffsetTo(getNulChkTableOffset());  }
-  public Address nulChkTableBegin()     { return headerBegin().addOffsetTo(getNulChkTableOffset());  }
-  public Address nulChkTableEnd()       { return headerBegin().addOffsetTo(getNMethodEndOffset());   }
+  public Address stubEnd()              { return dataBegin();                                        }
+  public Address oopsBegin()            { return dataBegin();                                        }
+  public Address oopsEnd()              { return dataBegin().addOffsetTo(getMetadataOffset());       }
+  public Address metadataBegin()        { return dataBegin().addOffsetTo(getMetadataOffset());       }
 
+  public Address metadataEnd()          { return dataEnd();                                          }
+
+  public Address immutableDataBegin()   { return immutableDataField.getValue(addr);                         }
+  public Address immutableDataEnd()     { return immutableDataBegin().addOffsetTo(getImmutableDataSize());  }
+  public Address dependenciesBegin()    { return immutableDataBegin();                                      }
+  public Address dependenciesEnd()      { return immutableDataBegin().addOffsetTo(getHandlerTableOffset()); }
+  public Address handlerTableBegin()    { return immutableDataBegin().addOffsetTo(getHandlerTableOffset()); }
+  public Address handlerTableEnd()      { return immutableDataBegin().addOffsetTo(getNulChkTableOffset());  }
+  public Address nulChkTableBegin()     { return immutableDataBegin().addOffsetTo(getNulChkTableOffset());  }
+  public Address nulChkTableEnd()       { return immutableDataBegin().addOffsetTo(getScopesDataOffset());   }
+  public Address scopesDataBegin()      { return immutableDataBegin().addOffsetTo(getScopesDataOffset());   }
+  public Address scopesDataEnd()        { return immutableDataBegin().addOffsetTo(getScopesPCsOffset());    }
+  public Address scopesPCsBegin()       { return immutableDataBegin().addOffsetTo(getScopesPCsOffset());    }
+  public Address scopesPCsEnd()         { return immutableDataEnd();                                        }
+
+  public int getImmutableDataSize()     { return (int) immutableDataSizeField.getValue(addr);        }
   public int constantsSize()            { return (int) constantsEnd()   .minus(constantsBegin());    }
   public int instsSize()                { return (int) instsEnd()       .minus(instsBegin());        }
   public int stubSize()                 { return (int) stubEnd()        .minus(stubBegin());         }
@@ -149,7 +155,10 @@ public class NMethod extends CompiledMethod {
     return
       constantsSize()    +
       instsSize()        +
-      stubSize()         +
+      stubSize();
+  }
+  public int immutableDataSize() {
+    return
       scopesDataSize()   +
       scopesPCsSize()    +
       dependenciesSize() +
@@ -171,8 +180,8 @@ public class NMethod extends CompiledMethod {
   public int getMetadataLength() { return (int) (metadataSize() / VM.getVM().getOopSize()); }
 
   /** Entry points */
-  public Address getEntryPoint()         { return entryPointField.getValue(addr);         }
-  public Address getVerifiedEntryPoint() { return verifiedEntryPointField.getValue(addr); }
+  public Address getEntryPoint()         { return codeBegin().addOffsetTo(getEntryPointOffset());         }
+  public Address getVerifiedEntryPoint() { return codeBegin().addOffsetTo(getVerifiedEntryPointOffset()); }
 
   /** Support for oops in scopes and relocs. Note: index 0 is reserved for null. */
   public OopHandle getOopAt(int index) {
@@ -416,10 +425,10 @@ public class NMethod extends CompiledMethod {
   // FIXME: add isPatchableAt()
 
   /** Support for code generation. Only here for proof-of-concept. */
-  public static int getEntryPointOffset()            { return (int) entryPointField.getOffset();            }
-  public static int getVerifiedEntryPointOffset()    { return (int) verifiedEntryPointField.getOffset();    }
-  public static int getOSREntryPointOffset()         { return (int) osrEntryPointField.getOffset();         }
-  public static int getEntryBCIOffset()              { return (int) entryBCIField.getOffset();              }
+  public int getEntryPointOffset()            { return (int) entryOffsetField.getValue(addr);        }
+  public int getVerifiedEntryPointOffset()    { return (int) verifiedEntryOffsetField.getValue(addr);}
+  public static int getOSREntryPointOffset()  { return (int) osrEntryPointField.getOffset();         }
+  public static int getEntryBCIOffset()       { return (int) entryBCIField.getOffset();              }
 
   public void print() {
     printOn(System.out);
@@ -498,12 +507,10 @@ public class NMethod extends CompiledMethod {
   private int getEntryBCI()           { return (int) entryBCIField          .getValue(addr); }
   private int getExceptionOffset()    { return (int) exceptionOffsetField   .getValue(addr); }
   private int getStubOffset()         { return (int) stubOffsetField        .getValue(addr); }
-  private int getOopsOffset()         { return (int) oopsOffsetField        .getValue(addr); }
   private int getMetadataOffset()     { return (int) metadataOffsetField    .getValue(addr); }
+  private int getScopesDataOffset()   { return (int) scopesDataOffsetField  .getValue(addr); }
   private int getScopesPCsOffset()    { return (int) scopesPCsOffsetField   .getValue(addr); }
-  private int getDependenciesOffset() { return (int) dependenciesOffsetField.getValue(addr); }
   private int getHandlerTableOffset() { return (int) handlerTableOffsetField.getValue(addr); }
   private int getNulChkTableOffset()  { return (int) nulChkTableOffsetField .getValue(addr); }
-  private int getNMethodEndOffset()   { return (int) nmethodEndOffsetField  .getValue(addr); }
   private int getCompLevel()          { return (int) compLevelField         .getValue(addr); }
 }

--- a/test/hotspot/jtreg/compiler/c1/TestLinearScanOrderMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestLinearScanOrderMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8207355
  * @compile TestLinearScanOrder.jasm
  * @run main/othervm -Xcomp -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:NMethodSizeLimit=655360
  *                   -XX:CompileCommand=compileonly,compiler.c1.TestLinearScanOrder::test
  *                   compiler.c1.TestLinearScanOrderMain
  */


### PR DESCRIPTION
Summary: Include these changes
partial backport of 8329332: Remove CompiledMethod and CodeBlobLayout classes
[Backport] 8329433: Reduce nmethod header size
[Backport] 8331087: Move immutable nmethod data from CodeCache

Testing: CI testing

Reviewers: Yude Lin, zhuoren.wz

Issue: https://github.com/dragonwell-project/dragonwell21/issues/88