### PR TITLE
[Backport] Lilliput test fixes and conditional option enabling

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -832,6 +832,11 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$($1_JTREG_PROBLEM_LIST))
   endif
 
+  # Add more Lilliput-specific ProblemLists when UCOH is enabled
+  ifneq ($$(findstring -XX:+UseCompactObjectHeaders, $$(TEST_OPTS)), )
+    JTREG_EXTRA_PROBLEM_LISTS += $(TOPDIR)/test/hotspot/jtreg/ProblemList-lilliput.txt
+  endif
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3087,7 +3087,9 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
 #ifdef _LP64
   if (UseCompactObjectHeaders && UseZGC && !ZGenerational) {
-    warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    if (FLAG_IS_CMDLINE(UseCompactObjectHeaders)) {
+      warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    }
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   }
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3092,6 +3092,12 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
     }
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   }
+#if INCLUDE_JVMCI
+  if (UseCompactObjectHeaders && EnableJVMCI) {
+    warning("JVMCI does not work with compact object headers, disabling UseCompactObjectHeaders");
+    FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
+  }
+#endif
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {
     warning("Compact object headers require compressed class pointers. Disabling compact object headers.");
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);

--- a/test/hotspot/gtest/oops/test_arrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_arrayOop.cpp
@@ -82,7 +82,18 @@ TEST_VM(arrayOopDesc, narrowOop) {
 
 TEST_VM(arrayOopDesc, base_offset) {
 #ifdef _LP64
-  if (UseCompressedClassPointers) {
+  if (UseCompactObjectHeaders) {
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 12);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    12);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   12);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_CHAR),    12);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_INT),     12);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_FLOAT),   12);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_LONG),    16);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_DOUBLE),  16);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_OBJECT),  12);
+    EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_ARRAY),   12);
+  } else if (UseCompressedClassPointers) {
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BOOLEAN), 16);
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_BYTE),    16);
     EXPECT_EQ(arrayOopDesc::base_offset_in_bytes(T_SHORT),   16);

--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -28,29 +28,41 @@
 
 TEST_VM(objArrayOop, osize) {
   static const struct {
-    int objal; bool ccp; bool coops; int result;
+    int objal; bool ccp; bool coops; bool coh; int result;
   } x[] = {
-//    ObjAligInB, UseCCP, UseCoops, object size in heap words
+//    ObjAligInB, UseCCP, UseCoops, UseCOH, object size in heap words
 #ifdef _LP64
-    { 8,          false,  false,    4 },  // 20 byte header, 8 byte oops
-    { 8,          false,  true,     3 },  // 20 byte header, 4 byte oops
-    { 8,          true,   false,    3 },  // 16 byte header, 8 byte oops
-    { 8,          true,   true,     3 },  // 16 byte header, 4 byte oops
-    { 16,         false,  false,    4 },  // 20 byte header, 8 byte oops, 16-byte align
-    { 16,         false,  true,     4 },  // 20 byte header, 4 byte oops, 16-byte align
-    { 16,         true,   false,    4 },  // 16 byte header, 8 byte oops, 16-byte align
-    { 16,         true,   true,     4 },  // 16 byte header, 4 byte oops, 16-byte align
-    { 256,        false,  false,    32 }, // 20 byte header, 8 byte oops, 256-byte align
-    { 256,        false,  true,     32 }, // 20 byte header, 4 byte oops, 256-byte align
-    { 256,        true,   false,    32 }, // 16 byte header, 8 byte oops, 256-byte align
-    { 256,        true,   true,     32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 8,          false,  false,    false,  4 },  // 20 byte header, 8 byte oops
+    { 8,          false,  true,     false,  3 },  // 20 byte header, 4 byte oops
+    { 8,          true,   false,    false,  3 },  // 16 byte header, 8 byte oops
+    { 8,          true,   true,     false,  3 },  // 16 byte header, 4 byte oops
+    { 16,         false,  false,    false,  4 },  // 20 byte header, 8 byte oops, 16-byte align
+    { 16,         false,  true,     false,  4 },  // 20 byte header, 4 byte oops, 16-byte align
+    { 16,         true,   false,    false,  4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,   true,     false,  4 },  // 16 byte header, 4 byte oops, 16-byte align
+    { 256,        false,  false,    false,  32 }, // 20 byte header, 8 byte oops, 256-byte align
+    { 256,        false,  true,     false,  32 }, // 20 byte header, 4 byte oops, 256-byte align
+    { 256,        true,   false,    false,  32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,   true,     false,  32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 8,          false,  false,    true,   3 },  // 16 byte header, 8 byte oops
+    { 8,          false,  true,     true,   2 },  // 12 byte header, 4 byte oops
+    { 8,          true,   false,    true,   3 },  // 16 byte header, 8 byte oops
+    { 8,          true,   true,     true,   2 },  // 12 byte header, 4 byte oops
+    { 16,         false,  false,    true,   4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         false,  true,     true,   2 },  // 12 byte header, 4 byte oops, 16-byte align
+    { 16,         true,   false,    true,   4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,   true,     true,   2 },  // 12 byte header, 4 byte oops, 16-byte align
+    { 256,        false,  false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        false,  true,     true,   32 }, // 12 byte header, 4 byte oops, 256-byte align
+    { 256,        true,   false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,   true,     true,   32 }, // 12 byte header, 4 byte oops, 256-byte align
 #else
-    { 8,          false,  false,    4 }, // 12 byte header, 4 byte oops, wordsize 4
+    { 8,          false,  false,    false,  4 }, // 12 byte header, 4 byte oops, wordsize 4
 #endif
-    { -1,         false,  false,   -1 }
+    { -1,         false,  false,    false, -1 }
   };
   for (int i = 0; x[i].result != -1; i++) {
-    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops) {
+    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops && x[i].coh == UseCompactObjectHeaders) {
       EXPECT_EQ(objArrayOopDesc::object_size(1), (size_t)x[i].result);
     }
   }

--- a/test/hotspot/jtreg/ProblemList-lilliput.txt
+++ b/test/hotspot/jtreg/ProblemList-lilliput.txt
@@ -26,3 +26,15 @@
 # The test exclusions are for the cases when we are sure the tests would fail
 # for the known and innocuous implementation reasons.
 #
+
+
+compiler/ciReplay/TestInlining.java 8316441 generic-all
+compiler/ciReplay/TestInliningProtectionDomain.java 8316441 generic-all
+compiler/ciReplay/TestServerVM.java 8316441 generic-all
+compiler/ciReplay/TestUnresolvedClasses.java 8316441 generic-all
+compiler/ciReplay/TestLambdas.java 8316441 generic-all
+compiler/ciReplay/TestDumpReplay.java 8316441 generic-all
+compiler/ciReplay/TestDumpReplayCommandLine.java 8316441 generic-all
+compiler/ciReplay/TestIncrementalInlining.java 8316441 generic-all
+compiler/ciReplay/TestInvalidReplayFile.java 8316441 generic-all
+compiler/ciReplay/TestNoClassFile.java 8316441 generic-all

--- a/test/hotspot/jtreg/ProblemList-lilliput.txt
+++ b/test/hotspot/jtreg/ProblemList-lilliput.txt
@@ -1,0 +1,28 @@
+#
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#
+# These tests are problematic when +UseCompactObjectHeaders is enabled.
+# The test exclusions are for the cases when we are sure the tests would fail
+# for the known and innocuous implementation reasons.
+#


### PR DESCRIPTION
Backport the following test-only changes:
8316367: [Lilliput/JDK21] Provide infrastructure for Lilliput-specific ProblemList
8316442: [Lilliput/JDK21] Problem-list compiler/ciReplay tests
8319163: [Lilliput/JDK21] Fix arrayOopDesc gtest
8319135: [Lilliput] Fix objArrayOop gtest

Also backport the trivially easy to understand change:
8319524: [Lilliput] Only warn when compact headers are explicitly enabled

Additionally, disable compact object headers in JVMCI