### PR TITLE
[Misc] Add globals_ext.hpp for Dragonwell specific flags

### DIFF
--- a/src/hotspot/share/runtime/flags/allFlags.hpp
+++ b/src/hotspot/share/runtime/flags/allFlags.hpp
@@ -148,6 +148,15 @@
     product_pd,               \
     notproduct,               \
     range,                    \
+    constraint)               \
+                              \
+  DRAGONWELL_FLAGS(           \
+    develop,                  \
+    develop_pd,               \
+    product,                  \
+    product_pd,               \
+    notproduct,               \
+    range,                    \
     constraint)
 
 #define ALL_CONSTRAINTS(f) \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -33,6 +33,7 @@
 #include CPU_HEADER(globals)
 #include OS_HEADER(globals)
 #include OS_CPU_HEADER(globals)
+#include "runtime/globals_ext.hpp"
 
 // develop flags are settable / visible only during development and are constant in the PRODUCT version
 // product flags are always settable / visible
@@ -1997,5 +1998,6 @@ DECLARE_FLAGS(LP64_RUNTIME_FLAGS)
 DECLARE_ARCH_FLAGS(ARCH_FLAGS)
 DECLARE_FLAGS(RUNTIME_FLAGS)
 DECLARE_FLAGS(RUNTIME_OS_FLAGS)
+DECLARE_FLAGS(DRAGONWELL_FLAGS)
 
 #endif // SHARE_RUNTIME_GLOBALS_HPP

--- a/src/hotspot/share/runtime/globals_ext.hpp
+++ b/src/hotspot/share/runtime/globals_ext.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_GLOBALS_EXT_HPP
+#define SHARE_RUNTIME_GLOBALS_EXT_HPP
+
+#define DRAGONWELL_FLAGS(develop,                                              \
+                         develop_pd,                                           \
+                         product,                                              \
+                         product_pd,                                           \
+                         notproduct,                                           \
+                         range,                                                \
+                         constraint)                                           \
+  product(bool, UseNewCode4, false, DIAGNOSTIC,                                \
+          "Testing Only: Use the new version while testing")                   \
+
+#endif // SHARE_RUNTIME_GLOBALS_EXT_HPP
+


### PR DESCRIPTION
Summary:
As we did in dragonwell 8 and 11, use globals_ext.hpp for dragonwell specific flags.

Testing: CI

Reviewers: Yude Lin, yueshi.zwj

Issue: https://github.com/dragonwell-project/dragonwell21/issues/93