### PR TITLE
[Lilliput] Test fix for EATests after backport

### DIFF
--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -1999,7 +1999,7 @@ class EARelockingNestedInflated_03Target extends EATestCaseBaseTarget {
         // Use new lock. lockInflatedByContention might have been inflated because of recursion.
         lockInflatedByContention = new XYVal(1, 1);
         // Start thread that tries to enter lockInflatedByContention while the main thread owns it -> inflation
-        TestScaffold.newThread(() -> {
+        DebuggeeWrapper.newThread(() -> {
             while (true) {
                 synchronized (testCase) {
                     try {


### PR DESCRIPTION
Summary: Change unsupported test api

Testing: com/sun/jdi/EATests.java

Reviewers: mmyxym, jia-wei-tang

Issue: https://github.com/dragonwell-project/dragonwell21/issues/132


For unknown reason https://github.com/dragonwell-project/dragonwell21/pull/120/commits/de50f9439df04135821e80ffabdeec4e2ce9525b changes a test which caused failure. We change it back to be the same as jdk-tip.