### PR TITLE
[JIT] Replace LoadLoad membar with load-acquire

### DIFF
--- a/src/hotspot/share/runtime/globals_ext.hpp
+++ b/src/hotspot/share/runtime/globals_ext.hpp
@@ -35,6 +35,9 @@
                          constraint)                                           \
   product(bool, UseNewCode4, false, DIAGNOSTIC,                                \
           "Testing Only: Use the new version while testing")                   \
+                                                                               \
+  product(bool, ReplaceLLMemBarWithLoadAcquire, false,                         \
+          "Replace LoadLoad membar with load-acquire")                         \
 
 #endif // SHARE_RUNTIME_GLOBALS_EXT_HPP
 


### PR DESCRIPTION
Summary: In nmethod entry barrier, use lighter instruction.

Testing: CICD

Reviewers: mmyxym, kuaiwei

Issue: https://github.com/dragonwell-project/dragonwell21/issues/174