### PR TITLE
Backport toString相关优化和线程安全问题

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -27,6 +27,7 @@ package java.lang;
 
 import jdk.internal.math.DoubleToDecimal;
 import jdk.internal.math.FloatToDecimal;
+import jdk.internal.util.DecimalDigits;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
@@ -839,12 +840,13 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     public AbstractStringBuilder append(int i) {
         int count = this.count;
-        int spaceNeeded = count + Integer.stringSize(i);
-        ensureCapacityInternal(spaceNeeded);
-        if (isLatin1()) {
-            Integer.getChars(i, spaceNeeded, value);
+        int spaceNeeded = count + DecimalDigits.stringSize(i);
+        byte coder = this.coder;
+        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
+        if (coder == LATIN1) {
+            DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
         } else {
-            StringUTF16.getChars(i, count, spaceNeeded, value);
+            DecimalDigits.getCharsUTF16(i, spaceNeeded, value);
         }
         this.count = spaceNeeded;
         return this;
@@ -864,12 +866,13 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     public AbstractStringBuilder append(long l) {
         int count = this.count;
-        int spaceNeeded = count + Long.stringSize(l);
-        ensureCapacityInternal(spaceNeeded);
-        if (isLatin1()) {
-            Long.getChars(l, spaceNeeded, value);
+        int spaceNeeded = count + DecimalDigits.stringSize(l);
+        byte coder = this.coder;
+        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
+        if (coder == LATIN1) {
+            DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
         } else {
-            StringUTF16.getChars(l, count, spaceNeeded, value);
+            DecimalDigits.getCharsUTF16(l, spaceNeeded, value);
         }
         this.count = spaceNeeded;
         return this;

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import jdk.internal.misc.CDS;
+import jdk.internal.util.DecimalDigits;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
@@ -489,14 +490,14 @@ public final class Long extends Number
      * @return  a string representation of the argument in base&nbsp;10.
      */
     public static String toString(long i) {
-        int size = stringSize(i);
+        int size = DecimalDigits.stringSize(i);
         if (COMPACT_STRINGS) {
             byte[] buf = new byte[size];
-            getChars(i, size, buf);
+            DecimalDigits.getCharsLatin1(i, size, buf);
             return new String(buf, LATIN1);
         } else {
             byte[] buf = new byte[size * 2];
-            StringUTF16.getChars(i, size, buf);
+            DecimalDigits.getCharsUTF16(i, size, buf);
             return new String(buf, UTF16);
         }
     }
@@ -517,65 +518,6 @@ public final class Long extends Number
      */
     public static String toUnsignedString(long i) {
         return toUnsignedString(i, 10);
-    }
-
-    /**
-     * Places characters representing the long i into the
-     * character array buf. The characters are placed into
-     * the buffer backwards starting with the least significant
-     * digit at the specified index (exclusive), and working
-     * backwards from there.
-     *
-     * @implNote This method converts positive inputs into negative
-     * values, to cover the Long.MIN_VALUE case. Converting otherwise
-     * (negative to positive) will expose -Long.MIN_VALUE that overflows
-     * long.
-     *
-     * @param i     value to convert
-     * @param index next index, after the least significant digit
-     * @param buf   target buffer, Latin1-encoded
-     * @return index of the most significant digit or minus sign, if present
-     */
-    static int getChars(long i, int index, byte[] buf) {
-        long q;
-        int r;
-        int charPos = index;
-
-        boolean negative = (i < 0);
-        if (!negative) {
-            i = -i;
-        }
-
-        // Get 2 digits/iteration using longs until quotient fits into an int
-        while (i <= Integer.MIN_VALUE) {
-            q = i / 100;
-            r = (int)((q * 100) - i);
-            i = q;
-            buf[--charPos] = Integer.DigitOnes[r];
-            buf[--charPos] = Integer.DigitTens[r];
-        }
-
-        // Get 2 digits/iteration using ints
-        int q2;
-        int i2 = (int)i;
-        while (i2 <= -100) {
-            q2 = i2 / 100;
-            r  = (q2 * 100) - i2;
-            i2 = q2;
-            buf[--charPos] = Integer.DigitOnes[r];
-            buf[--charPos] = Integer.DigitTens[r];
-        }
-
-        // We know there are at most two digits left at this point.
-        buf[--charPos] = Integer.DigitOnes[-i2];
-        if (i2 < -9) {
-            buf[--charPos] = Integer.DigitTens[-i2];
-        }
-
-        if (negative) {
-            buf[--charPos] = (byte)'-';
-        }
-        return charPos;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -26,6 +26,7 @@
 package java.lang;
 
 import jdk.internal.misc.Unsafe;
+import jdk.internal.util.DecimalDigits;
 import jdk.internal.javac.PreviewFeature;
 import jdk.internal.util.FormatConcatItem;
 import jdk.internal.vm.annotation.ForceInline;
@@ -343,9 +344,9 @@ final class StringConcatHelper {
      */
     private static long prepend(long indexCoder, byte[] buf, int value) {
         if (indexCoder < UTF16) {
-            return Integer.getChars(value, (int)indexCoder, buf);
+            return DecimalDigits.getCharsLatin1(value, (int)indexCoder, buf);
         } else {
-            return StringUTF16.getChars(value, (int)indexCoder, buf) | UTF16;
+            return DecimalDigits.getCharsUTF16(value, (int)indexCoder, buf) | UTF16;
         }
     }
 
@@ -378,9 +379,9 @@ final class StringConcatHelper {
      */
     private static long prepend(long indexCoder, byte[] buf, long value) {
         if (indexCoder < UTF16) {
-            return Long.getChars(value, (int)indexCoder, buf);
+            return DecimalDigits.getCharsLatin1(value, (int)indexCoder, buf);
         } else {
-            return StringUTF16.getChars(value, (int)indexCoder, buf) | UTF16;
+            return DecimalDigits.getCharsUTF16(value, (int)indexCoder, buf) | UTF16;
         }
     }
 
@@ -796,11 +797,11 @@ final class StringConcatHelper {
      */
     static int prepend(int index, byte coder, byte[] buf, int value, String prefix) {
         if (coder == String.LATIN1) {
-            index = Integer.getChars(value, index, buf);
+            index = DecimalDigits.getCharsLatin1(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
         } else {
-            index = StringUTF16.getChars(value, index, buf);
+            index = DecimalDigits.getCharsUTF16(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
         }
@@ -820,11 +821,11 @@ final class StringConcatHelper {
      */
     static int prepend(int index, byte coder, byte[] buf, long value, String prefix) {
         if (coder == String.LATIN1) {
-            index = Long.getChars(value, index, buf);
+            index = DecimalDigits.getCharsLatin1(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
         } else {
-            index = StringUTF16.getChars(value, index, buf);
+            index = DecimalDigits.getCharsUTF16(value, index, buf);
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
         }

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1357,20 +1357,6 @@ final class StringUTF16 {
         return codePointCount(val, beginIndex, endIndex, true /* checked */);
     }
 
-    public static int getChars(int i, int begin, int end, byte[] value) {
-        checkBoundsBeginEnd(begin, end, value);
-        int pos = getChars(i, end, value);
-        assert begin == pos;
-        return pos;
-    }
-
-    public static int getChars(long l, int begin, int end, byte[] value) {
-        checkBoundsBeginEnd(begin, end, value);
-        int pos = getChars(l, end, value);
-        assert begin == pos;
-        return pos;
-    }
-
     public static boolean contentEquals(byte[] v1, byte[] v2, int len) {
         checkBoundsOffCount(0, len, v2);
         for (int i = 0; i < len; i++) {
@@ -1508,100 +1494,6 @@ final class StringUTF16 {
     }
 
     static final int MAX_LENGTH = Integer.MAX_VALUE >> 1;
-
-    // Used by trusted callers.  Assumes all necessary bounds checks have
-    // been done by the caller.
-
-    /**
-     * This is a variant of {@link Integer#getChars(int, int, byte[])}, but for
-     * UTF-16 coder.
-     *
-     * @param i     value to convert
-     * @param index next index, after the least significant digit
-     * @param buf   target buffer, UTF16-coded.
-     * @return index of the most significant digit or minus sign, if present
-     */
-    static int getChars(int i, int index, byte[] buf) {
-        int q, r;
-        int charPos = index;
-
-        boolean negative = (i < 0);
-        if (!negative) {
-            i = -i;
-        }
-
-        // Get 2 digits/iteration using ints
-        while (i <= -100) {
-            q = i / 100;
-            r = (q * 100) - i;
-            i = q;
-            putChar(buf, --charPos, Integer.DigitOnes[r]);
-            putChar(buf, --charPos, Integer.DigitTens[r]);
-        }
-
-        // We know there are at most two digits left at this point.
-        putChar(buf, --charPos, Integer.DigitOnes[-i]);
-        if (i < -9) {
-            putChar(buf, --charPos, Integer.DigitTens[-i]);
-        }
-
-        if (negative) {
-            putChar(buf, --charPos, '-');
-        }
-        return charPos;
-    }
-
-    /**
-     * This is a variant of {@link Long#getChars(long, int, byte[])}, but for
-     * UTF-16 coder.
-     *
-     * @param i     value to convert
-     * @param index next index, after the least significant digit
-     * @param buf   target buffer, UTF16-coded.
-     * @return index of the most significant digit or minus sign, if present
-     */
-    static int getChars(long i, int index, byte[] buf) {
-        long q;
-        int r;
-        int charPos = index;
-
-        boolean negative = (i < 0);
-        if (!negative) {
-            i = -i;
-        }
-
-        // Get 2 digits/iteration using longs until quotient fits into an int
-        while (i <= Integer.MIN_VALUE) {
-            q = i / 100;
-            r = (int)((q * 100) - i);
-            i = q;
-            putChar(buf, --charPos, Integer.DigitOnes[r]);
-            putChar(buf, --charPos, Integer.DigitTens[r]);
-        }
-
-        // Get 2 digits/iteration using ints
-        int q2;
-        int i2 = (int)i;
-        while (i2 <= -100) {
-            q2 = i2 / 100;
-            r  = (q2 * 100) - i2;
-            i2 = q2;
-            putChar(buf, --charPos, Integer.DigitOnes[r]);
-            putChar(buf, --charPos, Integer.DigitTens[r]);
-        }
-
-        // We know there are at most two digits left at this point.
-        putChar(buf, --charPos, Integer.DigitOnes[-i2]);
-        if (i2 < -9) {
-            putChar(buf, --charPos, Integer.DigitTens[-i2]);
-        }
-
-        if (negative) {
-            putChar(buf, --charPos, '-');
-        }
-        return charPos;
-    }
-    // End of trusted methods.
 
     public static void checkIndex(int off, byte[] val) {
         String.checkIndex(off, length(val));

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -35,8 +35,14 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.io.StreamCorruptedException;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
+
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.util.DecimalDigits;
 
 /**
  * Immutable, arbitrary-precision signed decimal numbers.  A {@code
@@ -307,6 +313,8 @@ import java.util.Objects;
  * @since 1.1
  */
 public class BigDecimal extends Number implements Comparable<BigDecimal> {
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
     /*
      * Let l = log_2(10).
      * Then, L < l < L + ulp(L) / 2, that is, L = roundTiesToEven(l).
@@ -4147,103 +4155,6 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
         return BigDecimal.valueOf(1, this.scale(), 1);
     }
 
-    // Private class to build a string representation for BigDecimal object. The
-    // StringBuilder field acts as a buffer to hold the temporary representation
-    // of BigDecimal. The cmpCharArray holds all the characters for the compact
-    // representation of BigDecimal (except for '-' sign' if it is negative) if
-    // its intCompact field is not INFLATED.
-    static class StringBuilderHelper {
-        final StringBuilder sb;    // Placeholder for BigDecimal string
-        final char[] cmpCharArray; // character array to place the intCompact
-
-        StringBuilderHelper() {
-            sb = new StringBuilder(32);
-            // All non negative longs can be made to fit into 19 character array.
-            cmpCharArray = new char[19];
-        }
-
-        // Accessors.
-        StringBuilder getStringBuilder() {
-            sb.setLength(0);
-            return sb;
-        }
-
-        char[] getCompactCharArray() {
-            return cmpCharArray;
-        }
-
-        /**
-         * Places characters representing the intCompact in {@code long} into
-         * cmpCharArray and returns the offset to the array where the
-         * representation starts.
-         *
-         * @param intCompact the number to put into the cmpCharArray.
-         * @return offset to the array where the representation starts.
-         * Note: intCompact must be greater or equal to zero.
-         */
-        int putIntCompact(long intCompact) {
-            assert intCompact >= 0;
-
-            long q;
-            int r;
-            // since we start from the least significant digit, charPos points to
-            // the last character in cmpCharArray.
-            int charPos = cmpCharArray.length;
-
-            // Get 2 digits/iteration using longs until quotient fits into an int
-            while (intCompact > Integer.MAX_VALUE) {
-                q = intCompact / 100;
-                r = (int)(intCompact - q * 100);
-                intCompact = q;
-                cmpCharArray[--charPos] = DIGIT_ONES[r];
-                cmpCharArray[--charPos] = DIGIT_TENS[r];
-            }
-
-            // Get 2 digits/iteration using ints when i2 >= 100
-            int q2;
-            int i2 = (int)intCompact;
-            while (i2 >= 100) {
-                q2 = i2 / 100;
-                r  = i2 - q2 * 100;
-                i2 = q2;
-                cmpCharArray[--charPos] = DIGIT_ONES[r];
-                cmpCharArray[--charPos] = DIGIT_TENS[r];
-            }
-
-            cmpCharArray[--charPos] = DIGIT_ONES[i2];
-            if (i2 >= 10)
-                cmpCharArray[--charPos] = DIGIT_TENS[i2];
-
-            return charPos;
-        }
-
-        static final char[] DIGIT_TENS = {
-            '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
-            '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',
-            '2', '2', '2', '2', '2', '2', '2', '2', '2', '2',
-            '3', '3', '3', '3', '3', '3', '3', '3', '3', '3',
-            '4', '4', '4', '4', '4', '4', '4', '4', '4', '4',
-            '5', '5', '5', '5', '5', '5', '5', '5', '5', '5',
-            '6', '6', '6', '6', '6', '6', '6', '6', '6', '6',
-            '7', '7', '7', '7', '7', '7', '7', '7', '7', '7',
-            '8', '8', '8', '8', '8', '8', '8', '8', '8', '8',
-            '9', '9', '9', '9', '9', '9', '9', '9', '9', '9',
-        };
-
-        static final char[] DIGIT_ONES = {
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        };
-    }
-
     /**
      * Lay out this {@code BigDecimal} into a {@code char[]} array.
      * The Java 1.2 equivalent to this was called {@code getValueString}.
@@ -4263,18 +4174,24 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
             // currency fast path
             int lowInt = (int)intCompact % 100;
             int highInt = (int)intCompact / 100;
-            return (Integer.toString(highInt) + '.' +
-                    StringBuilderHelper.DIGIT_TENS[lowInt] +
-                    StringBuilderHelper.DIGIT_ONES[lowInt]) ;
+            int highIntSize = DecimalDigits.stringSize(highInt);
+            byte[] buf = new byte[highIntSize + 3];
+            DecimalDigits.getCharsLatin1(highInt, highIntSize, buf);
+            buf[highIntSize] = '.';
+            DecimalDigits.putPairLatin1(buf, highIntSize + 1, lowInt);
+            try {
+                return JLA.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
+            } catch (CharacterCodingException cce) {
+                throw new AssertionError(cce);
+            }
         }
 
-        StringBuilderHelper sbHelper = new StringBuilderHelper();
         char[] coeff;
         int offset;  // offset is the starting index for coeff array
         // Get the significand as an absolute value
         if (intCompact != INFLATED) {
-            offset = sbHelper.putIntCompact(Math.abs(intCompact));
-            coeff  = sbHelper.getCompactCharArray();
+            coeff = new char[19];
+            offset = DecimalDigits.getChars(Math.abs(intCompact), coeff.length, coeff);
         } else {
             offset = 0;
             coeff  = intVal.abs().toString().toCharArray();
@@ -4284,7 +4201,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
         // If E-notation is needed, length will be: +1 if negative, +1
         // if '.' needed, +2 for "E+", + up to 10 for adjusted exponent.
         // Otherwise it could have +1 if negative, plus leading "0.00000"
-        StringBuilder buf = sbHelper.getStringBuilder();
+        StringBuilder buf = new StringBuilder(32);
         if (signum() < 0)             // prefix '-' if negative
             buf.append('-');
         int coeffLen = coeff.length - offset;

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.util;
+
+import jdk.internal.misc.Unsafe;
+import jdk.internal.vm.annotation.Stable;
+
+import static jdk.internal.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+/**
+ * Digits class for decimal digits.
+ *
+ * @since 21
+ */
+public final class DecimalDigits {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    /**
+     * Each element of the array represents the packaging of two ascii characters based on little endian:<p>
+     * <pre>
+     *      00 -> '0' | ('0' << 8) -> 0x3030
+     *      01 -> '0' | ('1' << 8) -> 0x3130
+     *      02 -> '0' | ('2' << 8) -> 0x3230
+     *
+     *     ...
+     *
+     *      10 -> '1' | ('0' << 8) -> 0x3031
+     *      11 -> '1' | ('1' << 8) -> 0x3131
+     *      12 -> '1' | ('2' << 8) -> 0x3231
+     *
+     *     ...
+     *
+     *      97 -> '9' | ('7' << 8) -> 0x3739
+     *      98 -> '9' | ('8' << 8) -> 0x3839
+     *      99 -> '9' | ('9' << 8) -> 0x3939
+     * </pre>
+     */
+    @Stable
+    private static final short[] DIGITS;
+
+    static {
+        short[] digits = new short[128];
+
+        for (int i = 0; i < 10; i++) {
+            short hi = (short) (i + '0');
+            for (int j = 0; j < 10; j++) {
+                short lo = (short) ((j + '0') << 8);
+                digits[i * 10 + j] = (short) (hi | lo);
+            }
+        }
+        DIGITS = digits;
+    }
+
+    /**
+     * Constructor.
+     */
+    private DecimalDigits() {
+    }
+
+    /**
+     * Returns the string representation size for a given int value.
+     *
+     * @param x int value
+     * @return string size
+     *
+     * @implNote There are other ways to compute this: e.g. binary search,
+     * but values are biased heavily towards zero, and therefore linear search
+     * wins. The iteration results are also routinely inlined in the generated
+     * code after loop unrolling.
+     */
+    public static int stringSize(int x) {
+        int d = 1;
+        if (x >= 0) {
+            d = 0;
+            x = -x;
+        }
+        int p = -10;
+        for (int i = 1; i < 10; i++) {
+            if (x > p)
+                return i + d;
+            p = 10 * p;
+        }
+        return 10 + d;
+    }
+
+    /**
+     * Returns the string representation size for a given long value.
+     *
+     * @param x long value
+     * @return string size
+     *
+     * @implNote There are other ways to compute this: e.g. binary search,
+     * but values are biased heavily towards zero, and therefore linear search
+     * wins. The iteration results are also routinely inlined in the generated
+     * code after loop unrolling.
+     */
+    public static int stringSize(long x) {
+        int d = 1;
+        if (x >= 0) {
+            d = 0;
+            x = -x;
+        }
+        long p = -10;
+        for (int i = 1; i < 19; i++) {
+            if (x > p)
+                return i + d;
+            p = 10 * p;
+        }
+        return 19 + d;
+    }
+
+    /**
+     * Places characters representing the integer i into the
+     * character array buf. The characters are placed into
+     * the buffer backwards starting with the least significant
+     * digit at the specified index (exclusive), and working
+     * backwards from there.
+     *
+     * @implNote This method converts positive inputs into negative
+     * values, to cover the Integer.MIN_VALUE case. Converting otherwise
+     * (negative to positive) will expose -Integer.MIN_VALUE that overflows
+     * integer.
+     *
+     * @param i     value to convert
+     * @param index next index, after the least significant digit
+     * @param buf   target buffer, Latin1-encoded
+     * @return index of the most significant digit or minus sign, if present
+     */
+    public static int getCharsLatin1(int i, int index, byte[] buf) {
+        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
+        int q;
+        int charPos = index;
+
+        boolean negative = i < 0;
+        if (!negative) {
+            i = -i;
+        }
+
+        // Generate two digits per iteration
+        while (i <= -100) {
+            q = i / 100;
+            charPos -= 2;
+            putPairLatin1(buf, charPos, (q * 100) - i);
+            i = q;
+        }
+
+        // We know there are at most two digits left at this point.
+        if (i <= -10) {
+            charPos -= 2;
+            putPairLatin1(buf, charPos, -i);
+        } else {
+            putCharLatin1(buf, --charPos, '0' - i);
+        }
+
+        if (negative) {
+            putCharLatin1(buf, --charPos, '-');
+        }
+        return charPos;
+    }
+
+
+    /**
+     * Places characters representing the long i into the
+     * character array buf. The characters are placed into
+     * the buffer backwards starting with the least significant
+     * digit at the specified index (exclusive), and working
+     * backwards from there.
+     *
+     * @implNote This method converts positive inputs into negative
+     * values, to cover the Long.MIN_VALUE case. Converting otherwise
+     * (negative to positive) will expose -Long.MIN_VALUE that overflows
+     * long.
+     *
+     * @param i     value to convert
+     * @param index next index, after the least significant digit
+     * @param buf   target buffer, Latin1-encoded
+     * @return index of the most significant digit or minus sign, if present
+     */
+    public static int getCharsLatin1(long i, int index, byte[] buf) {
+        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
+        long q;
+        int charPos = index;
+
+        boolean negative = (i < 0);
+        if (!negative) {
+            i = -i;
+        }
+
+        // Get 2 digits/iteration using longs until quotient fits into an int
+        while (i < Integer.MIN_VALUE) {
+            q = i / 100;
+            charPos -= 2;
+            putPairLatin1(buf, charPos, (int)((q * 100) - i));
+            i = q;
+        }
+
+        // Get 2 digits/iteration using ints
+        int q2;
+        int i2 = (int)i;
+        while (i2 <= -100) {
+            q2 = i2 / 100;
+            charPos -= 2;
+            putPairLatin1(buf, charPos, (q2 * 100) - i2);
+            i2 = q2;
+        }
+
+        // We know there are at most two digits left at this point.
+        if (i2 <= -10) {
+            charPos -= 2;
+            putPairLatin1(buf, charPos, -i2);
+        } else {
+            putCharLatin1(buf, --charPos, '0' - i2);
+        }
+
+        if (negative) {
+            putCharLatin1(buf, --charPos, '-');
+        }
+        return charPos;
+    }
+
+
+    /**
+     * This is a variant of {@link DecimalDigits#getCharsLatin1(int, int, byte[])}, but for
+     * UTF-16 coder.
+     *
+     * @param i     value to convert
+     * @param index next index, after the least significant digit
+     * @param buf   target buffer, UTF16-coded.
+     * @return index of the most significant digit or minus sign, if present
+     */
+    public static int getCharsUTF16(int i, int index, byte[] buf) {
+        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
+        int q;
+        int charPos = index;
+
+        boolean negative = (i < 0);
+        if (!negative) {
+            i = -i;
+        }
+
+        // Get 2 digits/iteration using ints
+        while (i <= -100) {
+            q = i / 100;
+            charPos -= 2;
+            putPairUTF16(buf, charPos, (q * 100) - i);
+            i = q;
+        }
+
+        // We know there are at most two digits left at this point.
+        if (i <= -10) {
+            charPos -= 2;
+            putPairUTF16(buf, charPos, -i);
+        } else {
+            putCharUTF16(buf, --charPos, '0' - i);
+        }
+
+        if (negative) {
+            putCharUTF16(buf, --charPos, '-');
+        }
+        return charPos;
+    }
+
+
+    /**
+     * This is a variant of {@link DecimalDigits#getCharsLatin1(long, int, byte[])}, but for
+     * UTF-16 coder.
+     *
+     * @param i     value to convert
+     * @param index next index, after the least significant digit
+     * @param buf   target buffer, UTF16-coded.
+     * @return index of the most significant digit or minus sign, if present
+     */
+    public static int getCharsUTF16(long i, int index, byte[] buf) {
+        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
+        long q;
+        int charPos = index;
+
+        boolean negative = (i < 0);
+        if (!negative) {
+            i = -i;
+        }
+
+        // Get 2 digits/iteration using longs until quotient fits into an int
+        while (i < Integer.MIN_VALUE) {
+            q = i / 100;
+            charPos -= 2;
+            putPairUTF16(buf, charPos, (int)((q * 100) - i));
+            i = q;
+        }
+
+        // Get 2 digits/iteration using ints
+        int q2;
+        int i2 = (int)i;
+        while (i2 <= -100) {
+            q2 = i2 / 100;
+            charPos -= 2;
+            putPairUTF16(buf, charPos, (q2 * 100) - i2);
+            i2 = q2;
+        }
+
+        // We know there are at most two digits left at this point.
+        if (i2 <= -10) {
+            charPos -= 2;
+            putPairUTF16(buf, charPos, -i2);
+        } else {
+            putCharUTF16(buf, --charPos, '0' - i2);
+        }
+
+        if (negative) {
+            putCharUTF16(buf, --charPos, '-');
+        }
+        return charPos;
+    }
+
+    /**
+     * This is a variant of {@link DecimalDigits#getCharsUTF16(long, int, byte[])}, but for
+     * UTF-16 coder.
+     *
+     * @param i     value to convert
+     * @param index next index, after the least significant digit
+     * @param buf   target buffer, UTF16-coded.
+     * @return index of the most significant digit or minus sign, if present
+     */
+    public static int getChars(long i, int index, char[] buf) {
+        // Used by trusted callers.  Assumes all necessary bounds checks have been done by the caller.
+        long q;
+        int charPos = index;
+
+        boolean negative = (i < 0);
+        if (!negative) {
+            i = -i;
+        }
+
+        // Get 2 digits/iteration using longs until quotient fits into an int
+        while (i < Integer.MIN_VALUE) {
+            q = i / 100;
+            charPos -= 2;
+            putPair(buf, charPos, (int)((q * 100) - i));
+            i = q;
+        }
+
+        // Get 2 digits/iteration using ints
+        int q2;
+        int i2 = (int)i;
+        while (i2 <= -100) {
+            q2 = i2 / 100;
+            charPos -= 2;
+            putPair(buf, charPos, (q2 * 100) - i2);
+            i2 = q2;
+        }
+
+        // We know there are at most two digits left at this point.
+        if (i2 <= -10) {
+            charPos -= 2;
+            putPair(buf, charPos, -i2);
+        } else {
+            buf[--charPos] = (char) ('0' - i2);
+        }
+
+        if (negative) {
+            buf[--charPos] = '-';
+        }
+        return charPos;
+    }
+
+    /**
+     * Insert the 2-chars integer into the buf as 2 decimal digit ASCII chars,
+     * only least significant 16 bits of {@code v} are used.
+     * @param buf byte buffer to copy into
+     * @param charPos insert point
+     * @param v to convert
+     */
+    public static void putPair(char[] buf, int charPos, int v) {
+        int packed = DIGITS[v & 0x7f];
+        buf[charPos    ] = (char) (packed & 0xFF);
+        buf[charPos + 1] = (char) (packed >> 8);
+    }
+
+    /**
+     * Insert the 2-bytes integer into the buf as 2 decimal digit ASCII bytes,
+     * only least significant 16 bits of {@code v} are used.
+     * @param buf byte buffer to copy into
+     * @param charPos insert point
+     * @param v to convert
+     */
+    public static void putPairLatin1(byte[] buf, int charPos, int v) {
+        int packed = DIGITS[v & 0x7f];
+        putCharLatin1(buf, charPos, packed & 0xFF);
+        putCharLatin1(buf, charPos + 1, packed >> 8);
+    }
+
+    /**
+     * Insert the 2-chars integer into the buf as 2 decimal digit UTF16 bytes,
+     * only least significant 16 bits of {@code v} are used.
+     * @param buf byte buffer to copy into
+     * @param charPos insert point
+     * @param v to convert
+     */
+    public static void putPairUTF16(byte[] buf, int charPos, int v) {
+        int packed = DIGITS[v & 0x7f];
+        putCharUTF16(buf, charPos, packed & 0xFF);
+        putCharUTF16(buf, charPos + 1, packed >> 8);
+    }
+
+    private static void putCharLatin1(byte[] buf, int charPos, int c) {
+        UNSAFE.putByte(buf, ARRAY_BYTE_BASE_OFFSET + charPos, (byte) c);
+    }
+
+    private static void putCharUTF16(byte[] buf, int charPos, int c) {
+        UNSAFE.putCharUnaligned(buf, ARRAY_BYTE_BASE_OFFSET + ((long) charPos << 1), (char) c);
+    }
+}

--- a/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
+++ b/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
@@ -23,6 +23,8 @@
 
 package java.lang;
 
+import jdk.internal.util.DecimalDigits;
+
 /**
  * A helper class to get access to package-private members
  */
@@ -107,11 +109,17 @@ public class Helper {
     }
 
     public static int getChars(int i, int begin, int end, byte[] value) {
-        return StringUTF16.getChars(i, begin, end, value);
+        StringUTF16.checkBoundsBeginEnd(begin, end, value);
+        int pos = DecimalDigits.getCharsUTF16(i, end, value);
+        assert begin == pos;
+        return pos;
     }
 
     public static int getChars(long l, int begin, int end, byte[] value) {
-        return StringUTF16.getChars(l, begin, end, value);
+        StringUTF16.checkBoundsBeginEnd(begin, end, value);
+        int pos = DecimalDigits.getCharsUTF16(l, end, value);
+        assert begin == pos;
+        return pos;
     }
 
     public static boolean contentEquals(byte[] v1, byte[] v2, int len) {

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -54,6 +54,8 @@ public class StringBuilders {
     private StringBuilder sbLatin2;
     private StringBuilder sbUtf16;
     private StringBuilder sbUtf17;
+    private int[] intArray;
+    private long[] longArray;
 
     @Setup
     public void setup() {
@@ -69,6 +71,13 @@ public class StringBuilders {
         sbLatin2 = new StringBuilder("Latin1 string");
         sbUtf16 = new StringBuilder("UTF-\uFF11\uFF16 string");
         sbUtf17 = new StringBuilder("UTF-\uFF11\uFF16 string");
+        int size = 16;
+        intArray = new int[size];
+        longArray = new long[size];
+        for (int i = 0; i < longArray.length; i++) {
+            intArray[i] = ((100 * i + i) << 24) + 4543 + i * 4;
+            longArray[i] = ((100L * i + i) << 32) + 4543 + i * 4L;
+        }
     }
 
     @Benchmark
@@ -224,6 +233,45 @@ public class StringBuilders {
         return result.toString();
     }
 
+    @Benchmark
+    public int appendWithIntLatin1() {
+        StringBuilder buf = sbLatin1;
+        buf.setLength(0);
+        for (int i : intArray) {
+            buf.append(i);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithIntUtf16() {
+        StringBuilder buf = sbUtf16;
+        buf.setLength(0);
+        for (int i : intArray) {
+            buf.append(i);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithLongLatin1() {
+        StringBuilder buf = sbLatin1;
+        buf.setLength(0);
+        for (long l : longArray) {
+            buf.append(l);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithLongUtf16() {
+        StringBuilder buf = sbUtf16;
+        buf.setLength(0);
+        for (long l : longArray) {
+            buf.append(l);
+        }
+        return buf.length();
+    }
 
     @Benchmark
     public String toStringCharWithBool8() {


### PR DESCRIPTION
1. 修复 8349183: [BACKOUT] Optimization for StringBuilder append boolean & null 发现的问题 https://github.com/openjdk/jdk/pull/23420
2. 8343962: [REDO] Move getChars to DecimalDigits https://github.com/openjdk/jdk/pull/22023
3. Backport 8348870: Eliminate array bound checks in DecimalDigits https://github.com/openjdk/jdk/pull/23335
4. Backport https://github.com/openjdk/jdk/pull/23427

这些backport能提升Integer/Long.toString以及StringBuilder.append(int/long)的性能，并且修复并发操作StringBuilder可能导致JVM Crash的问题。