### PR TITLE
[BACKPORT]8335252: Reduce size of j.u.Formatter.Conversion#isValid

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4765,9 +4765,9 @@ public final class Formatter implements Closeable, Flushable {
                      DECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT_UPPER,
-                     LINE_SEPARATOR,
-                     PERCENT_SIGN -> true;
-                default -> false;
+                     LINE_SEPARATOR -> true;
+                // Don't put PERCENT_SIGN inside switch, as that will make the method size exceed 325 and cannot be inlined.
+                default -> c == PERCENT_SIGN;
             };
         }
 


### PR DESCRIPTION
urrently, the java.util.Formatter$Conversion::isValid method is implemented based on switch, which cannot be inlined because codeSize > 325. This problem can be avoided by implementing it with ImmutableBitSetPredicate.

use -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining to see the master branch:

@ 109   java.util.Formatter$Conversion::isValid (358 bytes)   failed to inline: hot method too big
current version

@ 109   java.util.Formatter$Conversion::isValid (10 bytes)   inline (hot)
  @ 4   jdk.internal.util.ImmutableBitSetPredicate$SmallImmutableBitSetPredicate::test (256 bytes)   inline (hot)