### PR TITLE
[Backport] 8345287: C2: live in computation is broken

### DIFF
--- a/src/hotspot/share/opto/live.cpp
+++ b/src/hotspot/share/opto/live.cpp
@@ -277,7 +277,7 @@ void PhaseLive::add_liveout(Block_List& worklist, Block* p, IndexSet* lo, Vector
 // Add a vector of live-in values to a given blocks live-in set.
 void PhaseLive::add_livein(Block *p, IndexSet *lo) {
   IndexSet *livein = &_livein[p->_pre_order-1];
-  if (!livein->is_empty()) {
+  if (!lo->is_empty()) {
     IndexSetIterator elements(lo);
     uint r;
     while ((r = elements.next()) != 0) {


### PR DESCRIPTION
Summary: Live in computation by PhaseLive results in always an empty live set. This doesn't cause any correctness issue but could affect performance.

Testing: CI testing

Reviewers: Kuai Wei, Wang Zhuo

Issue: https://github.com/dragonwell-project/dragonwell21/issues/240