### PR TITLE
[JIT] Static code reorder: allocate hottest methods into new code heap "NonProfiledHotCodeHeap"

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -434,6 +434,7 @@ void Compilation::install_code(int frame_size) {
     has_unsafe_access(),
     SharedRuntime::is_wide_vector(max_vector_size()),
     has_monitors(),
+    false,
     _immediate_oops_patched
   );
 }

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1033,6 +1033,7 @@ void ciEnv::register_method(ciMethod* target,
                             bool has_unsafe_access,
                             bool has_wide_vectors,
                             bool has_monitors,
+                            bool alloc_in_non_profiled_hot_code_heap,
                             int immediate_oops_patched,
                             RTMState  rtm_state) {
   VM_ENTRY_MARK;
@@ -1125,7 +1126,8 @@ void ciEnv::register_method(ciMethod* target,
                                debug_info(), dependencies(), code_buffer,
                                frame_words, oop_map_set,
                                handler_table, inc_table,
-                               compiler, CompLevel(task()->comp_level()));
+                               compiler, CompLevel(task()->comp_level()),
+                               alloc_in_non_profiled_hot_code_heap);
 
     // Free codeBlobs
     code_buffer->free_blob();

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -383,6 +383,7 @@ public:
                        bool                      has_unsafe_access,
                        bool                      has_wide_vectors,
                        bool                      has_monitors,
+                       bool                      alloc_in_non_profiled_hot_code_heap,
                        int                       immediate_oops_patched,
                        RTMState                  rtm_state = NoRTM);
 

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -39,6 +39,7 @@
 #include "oops/oop.inline.hpp"
 #include "prims/forte.hpp"
 #include "prims/jvmtiExport.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaFrameAnchor.hpp"
@@ -315,7 +316,13 @@ void* VtableBlob::operator new(size_t s, unsigned size) throw() {
   // this context as we hold the CompiledICLocker. So we just don't handle code
   // cache exhaustion here; we leave that for a later allocation that does not
   // hold the CompiledICLocker.
-  return CodeCache::allocate(size, CodeBlobType::NonNMethod, false /* handle_alloc_failure */);
+  CodeBlobType code_blob_type;
+  if (AllocIVtableStubInNonProfiledHotCodeHeap && NonProfiledHotCodeHeapSize) {
+    code_blob_type = CodeBlobType::MethodHotNonProfiled;
+  } else {
+    code_blob_type = CodeBlobType::NonNMethod;
+  }
+  return CodeCache::allocate(size, code_blob_type, false /* handle_alloc_failure */);
 }
 
 VtableBlob::VtableBlob(const char* name, int size) :
@@ -346,6 +353,8 @@ VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
       return nullptr;
     }
     blob = new (size) VtableBlob(name, size);
+    // Logging NonProfiledHotCodeHeap activities
+    CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Allocate", blob, size);
     CodeCache_lock->unlock();
   }
   // Track memory usage statistic after releasing CodeCache_lock

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -42,11 +42,12 @@ class OopMapSet;
 // CodeBlob Types
 // Used in the CodeCache to assign CodeBlobs to different CodeHeaps
 enum class CodeBlobType {
-  MethodNonProfiled   = 0,    // Execution level 1 and 4 (non-profiled) nmethods (including native nmethods)
-  MethodProfiled      = 1,    // Execution level 2 and 3 (profiled) nmethods
-  NonNMethod          = 2,    // Non-nmethods like Buffers, Adapters and Runtime Stubs
-  All                 = 3,    // All types (No code cache segmentation)
-  NumTypes            = 4     // Number of CodeBlobTypes
+  MethodNonProfiled    = 0,    // Execution level 1 and 4 (non-profiled) nmethods (including native nmethods)
+  MethodHotNonProfiled = 1,    // Hottest nmethods with NonProfiled
+  MethodProfiled       = 2,    // Execution level 2 and 3 (profiled) nmethods
+  NonNMethod           = 3,    // Non-nmethods like Buffers, Adapters and Runtime Stubs
+  All                  = 4,    // All types (No code cache segmentation)
+  NumTypes             = 5     // Number of CodeBlobTypes
 };
 
 // CodeBlob - superclass for all entries in the CodeCache.

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -178,13 +178,16 @@ GrowableArray<CodeHeap*>* CodeCache::_compiled_heaps = new(mtCode) GrowableArray
 GrowableArray<CodeHeap*>* CodeCache::_nmethod_heaps = new(mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
 GrowableArray<CodeHeap*>* CodeCache::_allocable_heaps = new(mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
 
-void CodeCache::check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, size_t non_profiled_size, size_t cache_size, bool all_set) {
-  size_t total_size = non_nmethod_size + profiled_size + non_profiled_size;
+void CodeCache::check_heap_sizes(size_t non_nmethod_size, size_t profiled_size,
+                                 size_t non_profiled_size, size_t non_profiled_hot_size,
+                                 size_t cache_size, bool all_set) {
+  size_t total_size = non_nmethod_size + profiled_size + non_profiled_size + non_profiled_hot_size;
   // Prepare error message
   const char* error = "Invalid code heap sizes";
   err_msg message("NonNMethodCodeHeapSize (" SIZE_FORMAT "K) + ProfiledCodeHeapSize (" SIZE_FORMAT "K)"
-                  " + NonProfiledCodeHeapSize (" SIZE_FORMAT "K) = " SIZE_FORMAT "K",
-          non_nmethod_size/K, profiled_size/K, non_profiled_size/K, total_size/K);
+                  " + NonProfiledCodeHeapSize (" SIZE_FORMAT "K) + ProfiledHotCodeHeapSize (" SIZE_FORMAT "K)"
+                  " = " SIZE_FORMAT "K",
+          non_nmethod_size/K, profiled_size/K, non_profiled_size/K, non_profiled_hot_size/K, total_size/K);
 
   if (total_size > cache_size) {
     // Some code heap sizes were explicitly set: total_size must be <= cache_size
@@ -197,21 +200,37 @@ void CodeCache::check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, 
   }
 }
 
+// Modify this function directly for easy review.
 void CodeCache::initialize_heaps() {
   bool non_nmethod_set      = FLAG_IS_CMDLINE(NonNMethodCodeHeapSize);
   bool profiled_set         = FLAG_IS_CMDLINE(ProfiledCodeHeapSize);
   bool non_profiled_set     = FLAG_IS_CMDLINE(NonProfiledCodeHeapSize);
+  bool non_profiled_hot_set = FLAG_IS_CMDLINE(NonProfiledHotCodeHeapSize);
+
   size_t min_size           = os::vm_page_size();
   size_t cache_size         = ReservedCodeCacheSize;
   size_t non_nmethod_size   = NonNMethodCodeHeapSize;
   size_t profiled_size      = ProfiledCodeHeapSize;
   size_t non_profiled_size  = NonProfiledCodeHeapSize;
+  size_t non_profiled_hot_size = NonProfiledHotCodeHeapSize;
+
   // Check if total size set via command line flags exceeds the reserved size
   check_heap_sizes((non_nmethod_set  ? non_nmethod_size  : min_size),
                    (profiled_set     ? profiled_size     : min_size),
                    (non_profiled_set ? non_profiled_size : min_size),
+                   non_profiled_hot_size,
                    cache_size,
-                   non_nmethod_set && profiled_set && non_profiled_set);
+                   non_nmethod_set && profiled_set && non_profiled_set && non_profiled_hot_set);
+
+  const size_t ps = page_size(false, 8);
+  const size_t alignment = MAX2(ps, os::vm_allocation_granularity());
+  if (non_profiled_hot_set) {
+    // Firstly meet the requirement of NonProfiledHotCodeHeapSize
+    non_profiled_hot_size = align_up(non_profiled_hot_size, alignment);
+    cache_size -= non_profiled_hot_size;
+  } else {
+    assert(non_profiled_hot_size == 0, "Default value of NonProfiledHotCodeHeapSize should be 0");
+  }
 
   // Determine size of compiler buffers
   size_t code_buffers_size = 0;
@@ -297,6 +316,13 @@ void CodeCache::initialize_heaps() {
     non_nmethod_size += non_profiled_size;
     non_profiled_size = 0;
   }
+  // We do not need the non-profiled HotCodeHeap, use all space for the non-nmethod CodeHeap
+  if (!heap_available(CodeBlobType::MethodHotNonProfiled)) {
+    non_nmethod_size += non_profiled_hot_size;
+    cache_size += non_profiled_hot_size;
+    non_profiled_hot_size = 0;
+  }
+
   // Make sure we have enough space for VM internal code
   uint min_code_cache_size = CodeCacheMinimumUseSpace DEBUG_ONLY(* 3);
   if (non_nmethod_size < min_code_cache_size) {
@@ -305,13 +331,23 @@ void CodeCache::initialize_heaps() {
         non_nmethod_size/K, min_code_cache_size/K));
   }
 
+  // Recover cache_size for the following operation after the initialization of all sizes of segmentation
+  cache_size += non_profiled_hot_size;
+
   // Verify sizes and update flag values
-  assert(non_profiled_size + profiled_size + non_nmethod_size == cache_size, "Invalid code heap sizes");
+  assert(non_profiled_size + non_profiled_hot_size + profiled_size + non_nmethod_size == cache_size,
+      "Invalid code heap sizes");
   FLAG_SET_ERGO(NonNMethodCodeHeapSize, non_nmethod_size);
   FLAG_SET_ERGO(ProfiledCodeHeapSize, profiled_size);
   FLAG_SET_ERGO(NonProfiledCodeHeapSize, non_profiled_size);
+  FLAG_SET_ERGO(NonProfiledHotCodeHeapSize, non_profiled_hot_size);
 
-  const size_t ps = page_size(false, 8);
+  if (AllocIVtableStubInNonProfiledHotCodeHeap) {
+    if (!non_profiled_hot_size) {
+      FLAG_SET_ERGO(AllocIVtableStubInNonProfiledHotCodeHeap, false);
+    }
+  }
+
   // Print warning if using large pages but not able to use the size given
   if (UseLargePages) {
     const size_t lg_ps = page_size(false, 1);
@@ -324,7 +360,6 @@ void CodeCache::initialize_heaps() {
 
   // If large page support is enabled, align code heaps according to large
   // page size to make sure that code cache is covered by large pages.
-  const size_t alignment = MAX2(ps, os::vm_allocation_granularity());
   non_nmethod_size = align_up(non_nmethod_size, alignment);
   profiled_size    = align_down(profiled_size, alignment);
   non_profiled_size = align_down(non_profiled_size, alignment);
@@ -333,6 +368,7 @@ void CodeCache::initialize_heaps() {
   // parts for the individual heaps. The memory layout looks like this:
   // ---------- high -----------
   //    Non-profiled nmethods
+  //  Non-profiled hot nmethods
   //         Non-nmethods
   //      Profiled nmethods
   // ---------- low ------------
@@ -340,7 +376,9 @@ void CodeCache::initialize_heaps() {
   ReservedSpace profiled_space      = rs.first_part(profiled_size);
   ReservedSpace rest                = rs.last_part(profiled_size);
   ReservedSpace non_method_space    = rest.first_part(non_nmethod_size);
-  ReservedSpace non_profiled_space  = rest.last_part(non_nmethod_size);
+  rest = rest.last_part(non_nmethod_size);
+  ReservedSpace non_profiled_hot_space  = rest.first_part(non_profiled_hot_size);
+  ReservedSpace non_profiled_space  = rest.last_part(non_profiled_hot_size);
 
   // Register CodeHeaps with LSan as we sometimes embed pointers to malloc memory.
   LSAN_REGISTER_ROOT_REGION(rs.base(), rs.size());
@@ -351,6 +389,8 @@ void CodeCache::initialize_heaps() {
   add_heap(profiled_space, "CodeHeap 'profiled nmethods'", CodeBlobType::MethodProfiled);
   // Tier 1 and tier 4 (non-profiled) methods and native methods
   add_heap(non_profiled_space, "CodeHeap 'non-profiled nmethods'", CodeBlobType::MethodNonProfiled);
+  // non-profiled hot methods
+  add_heap(non_profiled_hot_space, "CodeHeap 'non-profiled hot nmethods'", CodeBlobType::MethodHotNonProfiled);
 }
 
 size_t CodeCache::page_size(bool aligned, size_t min_pages) {
@@ -384,6 +424,12 @@ ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size, size_t rs_ps) {
 
 // Heaps available for allocation
 bool CodeCache::heap_available(CodeBlobType code_blob_type) {
+  if (code_blob_type == CodeBlobType::MethodHotNonProfiled) {
+    if (!NonProfiledHotCodeHeapSize) {
+      return false;
+    }
+  }
+
   if (!SegmentedCodeCache) {
     // No segmentation: use a single code heap
     return (code_blob_type == CodeBlobType::All);
@@ -396,7 +442,8 @@ bool CodeCache::heap_available(CodeBlobType code_blob_type) {
   } else {
     // No TieredCompilation: we only need the non-nmethod and non-profiled code heap
     return (code_blob_type == CodeBlobType::NonNMethod) ||
-           (code_blob_type == CodeBlobType::MethodNonProfiled);
+           (code_blob_type == CodeBlobType::MethodNonProfiled) ||
+           (code_blob_type == CodeBlobType::MethodHotNonProfiled);
   }
 }
 
@@ -407,6 +454,9 @@ const char* CodeCache::get_code_heap_flag_name(CodeBlobType code_blob_type) {
     break;
   case CodeBlobType::MethodNonProfiled:
     return "NonProfiledCodeHeapSize";
+    break;
+  case CodeBlobType::MethodHotNonProfiled:
+    return "NonProfiledHotCodeHeapSize";
     break;
   case CodeBlobType::MethodProfiled:
     return "ProfiledCodeHeapSize";
@@ -546,6 +596,9 @@ CodeBlob* CodeCache::allocate(int size, CodeBlobType code_blob_type, bool handle
         // NonNMethod -> MethodNonProfiled -> MethodProfiled (-> MethodNonProfiled)
         CodeBlobType type = code_blob_type;
         switch (type) {
+        case CodeBlobType::MethodHotNonProfiled:
+          type = CodeBlobType::MethodNonProfiled;
+          break;
         case CodeBlobType::NonNMethod:
           type = CodeBlobType::MethodNonProfiled;
           break;
@@ -1168,6 +1221,12 @@ void CodeCache::initialize() {
   // default page size.
   CodeCacheExpansionSize = align_up(CodeCacheExpansionSize, os::vm_page_size());
 
+  if (NonProfiledHotCodeHeapSize) {
+    if (!SegmentedCodeCache) {
+      vm_exit_during_initialization("SegmentedCodeCache should be enabled when NonProfiledHotCodeHeapSize is specified");
+    }
+  }
+
   if (SegmentedCodeCache) {
     // Use multiple code heaps
     initialize_heaps();
@@ -1176,6 +1235,7 @@ void CodeCache::initialize() {
     FLAG_SET_ERGO(NonNMethodCodeHeapSize, (uintx)os::vm_page_size());
     FLAG_SET_ERGO(ProfiledCodeHeapSize, 0);
     FLAG_SET_ERGO(NonProfiledCodeHeapSize, 0);
+    FLAG_SET_ERGO(NonProfiledHotCodeHeapSize, 0);
     ReservedCodeSpace rs = reserve_heap_memory(ReservedCodeCacheSize, page_size(false, 8));
     // Register CodeHeaps with LSan as we sometimes embed pointers to malloc memory.
     LSAN_REGISTER_ROOT_REGION(rs.base(), rs.size());
@@ -1741,6 +1801,61 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
                  CompileBroker::get_total_compiler_restarted_count());
     st->print_cr(" full_count=%d", full_count);
   }
+}
+
+void CodeCache::trace_non_profiled_hot_code_heap_activities(outputStream* st, const char* event, CodeBlob* cb, unsigned int size, bool detailed) {
+  if (!TraceNonProfiledHotCodeHeapActivities) {
+    return;
+  }
+
+  if (!CodeCache::heap_available(CodeBlobType::MethodHotNonProfiled)) {
+    return;
+  }
+
+  CodeHeap* heap = CodeCache::get_code_heap(cb);
+  assert(heap != NULL, "code heap of code blob should not be null");
+
+  if (heap->code_blob_type() != CodeBlobType::MethodHotNonProfiled) {
+    return;
+  }
+
+  st->print_cr("----------------------------------------------------------");
+
+  if (strncmp(event, "Free", 4)) {
+    if (cb->is_nmethod()) {
+      nmethod* nm = (nmethod*)cb;
+      st->print_cr("%s a hottest method in NonProfiledHotCodeHeap: %s::%s%s, nmethod size is %d",
+                   event, nm->method()->klass_name()->as_utf8(), nm->method()->name()->as_utf8(),
+                   nm->method()->signature()->as_utf8(), size);
+    } else {
+      st->print_cr("%s a vtable chunk in NonProfiledHotCodeHeap: chunk size is %d", event, size);
+    }
+  } else {
+    st->print_cr("%s a hottest method in NonProfiledHotCodeHeap", event);
+  }
+
+  size_t total = heap->high_boundary() - heap->low_boundary();
+
+  st->print("%s:", heap->name());
+  st->print_cr(" size=" SIZE_FORMAT "Kb used=" SIZE_FORMAT
+               "Kb max_used=" SIZE_FORMAT "Kb free=" SIZE_FORMAT "Kb",
+               total/K, (total - heap->unallocated_capacity())/K,
+               heap->max_allocated_capacity()/K, heap->unallocated_capacity()/K);
+
+  if (detailed) {
+    st->print_cr(" bounds [" INTPTR_FORMAT ", " INTPTR_FORMAT ", " INTPTR_FORMAT "]",
+                 p2i(heap->low_boundary()),
+                 p2i(heap->high()),
+                 p2i(heap->high_boundary()));
+
+    st->print_cr(" total_blobs=" UINT32_FORMAT " nmethods=" UINT32_FORMAT
+                 " full_count=" UINT32_FORMAT,
+                 heap->blob_count(),
+                 heap->nmethod_count(),
+                 heap->full_count());
+  }
+
+  return;
 }
 
 void CodeCache::print_codelist(outputStream* st) {

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -112,7 +112,9 @@ class CodeCache : AllStatic {
   // CodeHeap management
   static void initialize_heaps();                             // Initializes the CodeHeaps
   // Check the code heap sizes set by the user via command line
-  static void check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, size_t non_profiled_size, size_t cache_size, bool all_set);
+  static void check_heap_sizes(size_t non_nmethod_size, size_t profiled_size,
+                               size_t non_profiled_size, size_t cache_size,
+                               size_t non_profiled_hot_size, bool all_set);
   // Creates a new heap with the given name and size, containing CodeBlobs of the given type
   static void add_heap(ReservedSpace rs, const char* name, CodeBlobType code_blob_type);
   static CodeHeap* get_code_heap_containing(void* p);         // Returns the CodeHeap containing the given pointer, or nullptr
@@ -228,6 +230,7 @@ class CodeCache : AllStatic {
   static void verify();                          // verifies the code cache
   static void print_trace(const char* event, CodeBlob* cb, int size = 0) PRODUCT_RETURN;
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
+  static void trace_non_profiled_hot_code_heap_activities(outputStream* st, const char* event, CodeBlob* cb, unsigned int size = 0, bool detailed = true);
   static void log_state(outputStream* st);
   LINUX_ONLY(static void write_perf_map();)
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
@@ -266,15 +269,18 @@ class CodeCache : AllStatic {
   }
 
   static bool code_blob_type_accepts_compiled(CodeBlobType code_blob_type) {
+    // Accept compiled method: MethodHotNonProfiled should meet this requirement
     bool result = code_blob_type == CodeBlobType::All || code_blob_type <= CodeBlobType::MethodProfiled;
     return result;
   }
 
   static bool code_blob_type_accepts_nmethod(CodeBlobType type) {
+    // Accept nmethod: MethodHotNonProfiled should meet this requirement
     return type == CodeBlobType::All || type <= CodeBlobType::MethodProfiled;
   }
 
   static bool code_blob_type_accepts_allocable(CodeBlobType type) {
+    // Accept allocable: MethodHotNonProfiled should meet this requirement
     return type <= CodeBlobType::All;
   }
 
@@ -293,6 +299,18 @@ class CodeCache : AllStatic {
     }
     ShouldNotReachHere();
     return static_cast<CodeBlobType>(0);
+  }
+
+  // Returns the codeBlobType for the given method and compilation level
+  static CodeBlobType get_code_blob_type(const methodHandle& method, int comp_level, bool alloc_in_non_profiled_hot_code_heap) {
+    if (alloc_in_non_profiled_hot_code_heap && is_c2_compile(comp_level)) {
+      if (!method->is_native()) {
+        if (CodeCache::heap_available(CodeBlobType::MethodHotNonProfiled)) {
+          return CodeBlobType::MethodHotNonProfiled;
+        }
+      }
+    }
+    return get_code_blob_type(comp_level);
   }
 
   static void verify_clean_inline_caches();

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -532,6 +532,7 @@ nmethod* nmethod::new_native_nmethod(const methodHandle& method,
   OopMapSet* oop_maps,
   int exception_handler) {
   code_buffer->finalize_oop_references(method);
+
   // create nmethod
   nmethod* nm = nullptr;
   int native_nmethod_size = CodeBlob::allocation_size(code_buffer, sizeof(nmethod));
@@ -580,7 +581,8 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
   ExceptionHandlerTable* handler_table,
   ImplicitExceptionTable* nul_chk_table,
   AbstractCompiler* compiler,
-  CompLevel comp_level
+  CompLevel comp_level,
+  bool alloc_in_non_profiled_hot_code_heap
 #if INCLUDE_JVMCI
   , char* speculations,
   int speculations_len,
@@ -621,7 +623,9 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
-    nm = new (nmethod_size, comp_level)
+    CodeBlobType code_blob_type = CodeCache::get_code_blob_type(method, comp_level, alloc_in_non_profiled_hot_code_heap);
+
+    nm = new (nmethod_size, code_blob_type)
     nmethod(method(), compiler->type(), nmethod_size, immutable_data_size,
             compile_id, entry_bci, immutable_data, offsets, orig_pc_offset,
             debug_info, dependencies, code_buffer, frame_size, oop_maps,
@@ -657,6 +661,9 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
         }
       }
       NOT_PRODUCT(if (nm != nullptr)  note_java_nmethod(nm));
+
+      // Logging NonProfiledHotCodeHeap activities
+      CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Allocate", nm, nmethod_size);
     }
   }
   // Do verification and logging outside CodeCache_lock.
@@ -833,8 +840,8 @@ nmethod::nmethod(
   }
 }
 
-void* nmethod::operator new(size_t size, int nmethod_size, int comp_level) throw () {
-  return CodeCache::allocate(nmethod_size, CodeCache::get_code_blob_type(comp_level));
+void* nmethod::operator new(size_t size, int nmethod_size, CodeBlobType code_blob_type) throw () {
+  return CodeCache::allocate(nmethod_size, code_blob_type);
 }
 
 void* nmethod::operator new(size_t size, int nmethod_size, bool allow_NonNMethod_space) throw () {

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -318,7 +318,7 @@ class nmethod : public CompiledMethod {
           );
 
   // helper methods
-  void* operator new(size_t size, int nmethod_size, int comp_level) throw();
+  void* operator new(size_t size, int nmethod_size, CodeBlobType code_blob_type) throw();
   // For method handle intrinsics: Try MethodNonProfiled, MethodProfiled and NonNMethod.
   // Attention: Only allow NonNMethod space for special nmethods which don't need to be
   // findable by nmethod iterators! In particular, they must not contain oops!
@@ -351,7 +351,8 @@ class nmethod : public CompiledMethod {
                               ExceptionHandlerTable* handler_table,
                               ImplicitExceptionTable* nul_chk_table,
                               AbstractCompiler* compiler,
-                              CompLevel comp_level
+                              CompLevel comp_level,
+                              bool alloc_in_non_profiled_hot_code_heap
 #if INCLUDE_JVMCI
                               , char* speculations = nullptr,
                               int speculations_len = 0,

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -76,6 +76,7 @@ NOT_PRODUCT(cflags(PrintIdealPhase,     ccstrlist, "", PrintIdealPhase)) \
 NOT_PRODUCT(cflags(IGVPrintLevel,       intx, PrintIdealGraphLevel, IGVPrintLevel)) \
     cflags(VectorizeDebug,          uintx, 0, VectorizeDebug) \
     cflags(IncrementalInlineForceCleanup, bool, IncrementalInlineForceCleanup, IncrementalInlineForceCleanup) \
+    cflags(AllocInNonProfiledHotCodeHeap, bool, false, AllocInNonProfiledHotCodeHeap) \
     cflags(MaxNodeLimit,            intx, MaxNodeLimit, MaxNodeLimit)
 #else
   #define compilerdirectives_c2_flags(cflags)

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -74,6 +74,7 @@ class methodHandle;
   option(CompileThresholdScaling, "CompileThresholdScaling", Double) \
   option(ControlIntrinsic,  "ControlIntrinsic",  Ccstrlist) \
   option(DisableIntrinsic,  "DisableIntrinsic",  Ccstrlist) \
+  option(AllocInNonProfiledHotCodeHeap, "AllocInNonProfiledHotCodeHeap", Bool) \
   option(NoRTMLockEliding,  "NoRTMLockEliding",  Bool) \
   option(UseRTMLockEliding, "UseRTMLockEliding", Bool) \
   option(BlockLayoutByFrequency, "BlockLayoutByFrequency", Bool) \

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -299,7 +299,7 @@
   product(ccstr, CompileCommandFile, nullptr,                               \
           "Read compiler commands from this file [.hotspot_compiler]")      \
                                                                             \
-  product(ccstr, CompilerDirectivesFile, nullptr, DIAGNOSTIC,               \
+  product(ccstr, CompilerDirectivesFile, nullptr,                           \
           "Read compiler directives from this file")                        \
                                                                             \
   product(ccstrlist, CompileCommand, "",                                    \

--- a/src/hotspot/share/gc/shared/classUnloadingContext.cpp
+++ b/src/hotspot/share/gc/shared/classUnloadingContext.cpp
@@ -163,11 +163,15 @@ void ClassUnloadingContext::free_code_blobs() {
     for (nmethod* nm : *nmethod_set) {
       MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
       CodeCache::free(nm);
+      // Logging NonProfiledHotCodeHeap activities
+      CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Free", nm);
     }
   } else {
     MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
     for (nmethod* nm : *nmethod_set) {
       CodeCache::free(nm);
+      // Logging NonProfiledHotCodeHeap activities
+      CodeCache::trace_non_profiled_hot_code_heap_activities(tty, "Free", nm);
     }
   }
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2213,6 +2213,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                  frame_words, oop_map_set,
                                  handler_table, implicit_exception_table,
                                  compiler, comp_level,
+                                 false, // No jvmci support for allocation inside NonProfiledHotCodeHeap
                                  speculations, speculations_len, data);
 
 
@@ -2222,7 +2223,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
         {
           MutexUnlocker ml(Compile_lock);
           MutexUnlocker locker(MethodCompileQueue_lock);
-          CompileBroker::handle_full_code_cache(CodeCache::get_code_blob_type(comp_level));
+          CompileBroker::handle_full_code_cache(CodeCache::get_code_blob_type(method, comp_level, false));
         }
         result = JVMCI::cache_full;
       } else {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -617,6 +617,7 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
 #endif
                   _has_method_handle_invokes(false),
                   _clinit_barrier_on_entry(false),
+                  _alloc_in_non_profiled_hot_code_heap(false),
                   _stress_seed(0),
                   _comp_arena(mtCompiler),
                   _barrier_set_state(BarrierSet::barrier_set()->barrier_set_c2()->create_barrier_state(comp_arena())),
@@ -693,6 +694,9 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
 
   if (directive->ReplayInlineOption) {
     _replay_inline_data = ciReplay::load_inline_data(method(), entry_bci(), ci_env->comp_level());
+  }
+  if (NonProfiledHotCodeHeapSize) {
+    set_alloc_in_non_profiled_hot_code_heap(directive->AllocInNonProfiledHotCodeHeapOption);
   }
   set_print_inlining(directive->PrintInliningOption || PrintOptoInlining);
   set_print_intrinsics(directive->PrintIntrinsicsOption);
@@ -913,6 +917,7 @@ Compile::Compile( ciEnv* ci_env,
 #endif
     _has_method_handle_invokes(false),
     _clinit_barrier_on_entry(false),
+    _alloc_in_non_profiled_hot_code_heap(false),
     _stress_seed(0),
     _comp_arena(mtCompiler),
     _barrier_set_state(BarrierSet::barrier_set()->barrier_set_c2()->create_barrier_state(comp_arena())),

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -343,6 +343,7 @@ class Compile : public Phase {
   RTMState              _rtm_state;             // State of Restricted Transactional Memory usage
   int                   _loop_opts_cnt;         // loop opts round
   bool                  _clinit_barrier_on_entry; // True if clinit barrier is needed on nmethod entry
+  bool                  _alloc_in_non_profiled_hot_code_heap;
   uint                  _stress_seed;           // Seed for stress testing
 
   // Compilation environment.
@@ -639,6 +640,8 @@ class Compile : public Phase {
   void          set_max_node_limit(uint n)       { _max_node_limit = n; }
   bool              clinit_barrier_on_entry()       { return _clinit_barrier_on_entry; }
   void          set_clinit_barrier_on_entry(bool z) { _clinit_barrier_on_entry = z; }
+  bool              alloc_in_non_profiled_hot_code_heap() const { return _alloc_in_non_profiled_hot_code_heap; }
+  void          set_alloc_in_non_profiled_hot_code_heap(bool z) { _alloc_in_non_profiled_hot_code_heap = z; }
   bool              has_monitors() const         { return _has_monitors; }
   void          set_has_monitors(bool v)         { _has_monitors = v; }
 

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3353,6 +3353,7 @@ void PhaseOutput::install_code(ciMethod*         target,
                                      has_unsafe_access,
                                      SharedRuntime::is_wide_vector(C->max_vector_size()),
                                      C->has_monitors(),
+                                     C->alloc_in_non_profiled_hot_code_heap(),
                                      0,
                                      C->rtm_state());
 

--- a/src/hotspot/share/runtime/globals_ext.hpp
+++ b/src/hotspot/share/runtime/globals_ext.hpp
@@ -45,6 +45,16 @@
                                                                                \
   product(ccstrlist, NativeAccelerationUnit, "", EXPERIMENTAL,                 \
           "Load additional native acceleration units")                         \
+                                                                               \
+  product(bool, TraceNonProfiledHotCodeHeapActivities, false, DIAGNOSTIC,      \
+          "Trace activities of NonProfiledHotCodeHeap")                        \
+                                                                               \
+  product(uintx, NonProfiledHotCodeHeapSize, 0,                                \
+          "Size of hot code heap with non-profiled methods (in bytes)")        \
+          range(0, max_uintx)                                                  \
+                                                                               \
+  product(bool, AllocIVtableStubInNonProfiledHotCodeHeap, false,               \
+          "Allocate itable/vtable in NonProfiledHotCodeHeap")                  \
 
 #endif // SHARE_RUNTIME_GLOBALS_EXT_HPP
 

--- a/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
@@ -42,6 +42,20 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:-SegmentedCodeCache -Xmixed
  *                   compiler.codecache.OverflowCodeCacheTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:+TieredCompilation
+ *                   -XX:+SegmentedCodeCache -Xmixed
+ *                   compiler.codecache.OverflowCodeCacheTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:+TieredCompilation
+ *                   -XX:+SegmentedCodeCache -Xmixed
+ *                   -XX:NonProfiledHotCodeHeapSize=1m
+ *                   compiler.codecache.OverflowCodeCacheTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:-TieredCompilation
+ *                   -XX:+SegmentedCodeCache -Xmixed
+ *                   -XX:NonProfiledHotCodeHeapSize=1m
+ *                   compiler.codecache.OverflowCodeCacheTest
  */
 
 package compiler.codecache;

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/GenericCodeHeapSizeRunner.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/GenericCodeHeapSizeRunner.java
@@ -69,5 +69,13 @@ public class GenericCodeHeapSizeRunner implements CodeCacheCLITestCase.Runner {
                         BlobType.MethodProfiled.sizeOptionName,
                         expectedValues.profiled),
                 testCaseDescription.getTestOptions(options));
+
+        CommandLineOptionTest.verifyOptionValueForSameVM(
+                BlobType.MethodHotNonProfiled.sizeOptionName,
+                Long.toString(expectedValues.hotNonProfiled),
+                String.format("%s should have value %d.",
+                        BlobType.MethodHotNonProfiled.sizeOptionName,
+                        expectedValues.hotNonProfiled),
+                testCaseDescription.getTestOptions(options));
     }
 }

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/JVMStartupRunner.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/JVMStartupRunner.java
@@ -63,11 +63,11 @@ public class JVMStartupRunner implements CodeCacheCLITestCase.Runner {
             throws Throwable {
         verifyHeapSizesSum(options.reserved,
                 scaleCodeHeapSize(options.profiled), options.nonProfiled,
-                options.nonNmethods);
+                options.nonNmethods, options.hotNonProfiled);
         verifyHeapSizesSum(options.reserved, options.profiled,
-                scaleCodeHeapSize(options.nonProfiled), options.nonNmethods);
+                scaleCodeHeapSize(options.nonProfiled), options.nonNmethods, options.hotNonProfiled);
         verifyHeapSizesSum(options.reserved, options.profiled,
-                options.nonProfiled, scaleCodeHeapSize(options.nonNmethods));
+                options.nonProfiled, scaleCodeHeapSize(options.nonNmethods), options.hotNonProfiled);
     }
 
     /**
@@ -80,19 +80,21 @@ public class JVMStartupRunner implements CodeCacheCLITestCase.Runner {
         long profiled = options.profiled;
         long nonProfiled = options.nonProfiled;
         long nonNMethods = options.nonNmethods;
+        long hotNonProfiled = options.hotNonProfiled;
 
-        while (options.reserved == profiled + nonProfiled + nonNMethods) {
+        while (options.reserved == profiled + nonProfiled + nonNMethods + hotNonProfiled) {
             profiled = scaleCodeHeapSize(profiled);
             nonProfiled = scaleCodeHeapSize(nonProfiled);
             nonNMethods = scaleCodeHeapSize(nonNMethods);
+            hotNonProfiled = scaleCodeHeapSize(hotNonProfiled);
         }
 
         verifyHeapSizesSum(options.reserved, profiled, nonProfiled,
-                nonNMethods);
+                nonNMethods, hotNonProfiled);
     }
 
     private static void verifyHeapSizesSum(long reserved, long profiled,
-            long nonProfiled, long nonNmethods) throws Throwable {
+            long nonProfiled, long nonNmethods, long hotNonProfiled) throws Throwable {
         // JVM startup expected to fail when
         // sum(all code heap sizes) != reserved CC size
         CommandLineOptionTest.verifySameJVMStartup(
@@ -111,7 +113,9 @@ public class JVMStartupRunner implements CodeCacheCLITestCase.Runner {
                 CommandLineOptionTest.prepareNumericFlag(
                         BlobType.MethodNonProfiled.sizeOptionName, nonProfiled),
                 CommandLineOptionTest.prepareNumericFlag(
-                        BlobType.NonNMethod.sizeOptionName, nonNmethods));
+                        BlobType.NonNMethod.sizeOptionName, nonNmethods),
+                CommandLineOptionTest.prepareNumericFlag(
+                        BlobType.MethodHotNonProfiled.sizeOptionName, hotNonProfiled));
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -68,10 +68,19 @@ public class TestCodeHeapSizeOptions extends CodeCacheCLITestBase {
                         .CommonDescriptions.NON_TIERED.description,
                         GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.NON_TIERED_FOR_HOT_NON_PROFILED.description,
+                        GENERIC_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_1.description,
                         GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_1_FOR_HOT_NON_PROFILED.description,
+                        GENERIC_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_4.description,
+                        GENERIC_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_4_FOR_HOT_NON_PROFILED.description,
                         GENERIC_RUNNER),
                 JVM_STARTUP,
                 CODE_CACHE_FREE_SPACE);

--- a/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestBase.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestBase.java
@@ -40,7 +40,18 @@ public class CodeCacheCLITestBase {
                     CodeCacheOptions.mB(100)),
             new CodeCacheOptions(CodeCacheOptions.mB(60)),
             new CodeCacheOptions(CodeCacheOptions.mB(200)),
-            new CodeCacheOptions(CodeCacheOptions.mB(300))
+            new CodeCacheOptions(CodeCacheOptions.mB(300)),
+
+            // Support for NonProfiledHotCodeHeap
+            new CodeCacheOptions(CodeCacheOptions.mB(70),
+                    CodeCacheOptions.mB(20), CodeCacheOptions.mB(20),
+                    CodeCacheOptions.mB(20), CodeCacheOptions.mB(10)),
+            new CodeCacheOptions(CodeCacheOptions.mB(210),
+                    CodeCacheOptions.mB(75), CodeCacheOptions.mB(75),
+                    CodeCacheOptions.mB(50), CodeCacheOptions.mB(10)),
+            new CodeCacheOptions(CodeCacheOptions.mB(400),
+                    CodeCacheOptions.mB(100), CodeCacheOptions.mB(100),
+                    CodeCacheOptions.mB(100), CodeCacheOptions.mB(100))
     };
 
     private final CodeCacheCLITestCase[] testCases;

--- a/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
@@ -64,13 +64,22 @@ public class TestPrintCodeCacheOption extends CodeCacheCLITestBase {
                         .CommonDescriptions.NON_TIERED.description,
                         DEFAULT_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.NON_TIERED_FOR_HOT_NON_PROFILED.description,
+                        DEFAULT_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_0.description,
                         DEFAULT_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_1.description,
                         DEFAULT_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_1_FOR_HOT_NON_PROFILED.description,
+                        DEFAULT_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_4.description,
+                        DEFAULT_RUNNER),
+                new CodeCacheCLITestCase(CodeCacheCLITestCase
+                        .CommonDescriptions.TIERED_LEVEL_4_FOR_HOT_NON_PROFILED.description,
                         DEFAULT_RUNNER),
                 DISABLED_PRINT_CODE_CACHE);
     }

--- a/test/hotspot/jtreg/compiler/codecache/jmx/BeanTypeTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/BeanTypeTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.BeanTypeTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.BeanTypeTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.BeanTypeTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/CodeCacheUtils.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/CodeCacheUtils.java
@@ -95,7 +95,7 @@ public final class CodeCacheUtils {
      * @return boolean value, true if respective code heap is predictable
      */
     public static boolean isCodeHeapPredictable(BlobType btype) {
-        return btype == BlobType.MethodProfiled;
+        return btype == BlobType.MethodProfiled || btype == BlobType.MethodHotNonProfiled;
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/codecache/jmx/CodeHeapBeanPresenceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/CodeHeapBeanPresenceTest.java
@@ -38,6 +38,11 @@
  *     -XX:+WhiteBoxAPI
  *     -XX:+SegmentedCodeCache
  *     compiler.codecache.jmx.CodeHeapBeanPresenceTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.CodeHeapBeanPresenceTest
  */
 
 package compiler.codecache.jmx;

--- a/test/hotspot/jtreg/compiler/codecache/jmx/GetUsageTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/GetUsageTest.java
@@ -38,6 +38,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
  *     -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.GetUsageTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
+ *     -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.GetUsageTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/InitialAndMaxUsageTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/InitialAndMaxUsageTest.java
@@ -38,6 +38,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
  *     -XX:-MethodFlushing -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:CompileCommand=compileonly,null::* -XX:-UseLargePages
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.InitialAndMaxUsageTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
+ *     -XX:-MethodFlushing -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:CompileCommand=compileonly,null::* -XX:-UseLargePages
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.InitialAndMaxUsageTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/ManagerNamesTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/ManagerNamesTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.ManagerNamesTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.ManagerNamesTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.ManagerNamesTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/MemoryPoolsPresenceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/MemoryPoolsPresenceTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.MemoryPoolsPresenceTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.MemoryPoolsPresenceTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.MemoryPoolsPresenceTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/PeakUsageTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/PeakUsageTest.java
@@ -35,6 +35,11 @@
  *     compiler.codecache.jmx.PeakUsageTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.PeakUsageTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.PeakUsageTest
  * @summary testing of getPeakUsage() and resetPeakUsage for

--- a/test/hotspot/jtreg/compiler/codecache/jmx/PoolsIndependenceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/PoolsIndependenceTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.PoolsIndependenceTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.PoolsIndependenceTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.PoolsIndependenceTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/ThresholdNotificationsTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/ThresholdNotificationsTest.java
@@ -36,6 +36,11 @@
  *     compiler.codecache.jmx.ThresholdNotificationsTest
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
  *     -XX:+WhiteBoxAPI -XX:-MethodFlushing -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.ThresholdNotificationsTest
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbootclasspath/a:. -XX:-UseCodeCacheFlushing
+ *     -XX:+WhiteBoxAPI -XX:-MethodFlushing -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.ThresholdNotificationsTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededSeveralTimesTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededSeveralTimesTest.java
@@ -39,6 +39,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *      -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *      -XX:CompileCommand=compileonly,null::* -Djdk.test.lib.iterations=10
+ *      -XX:+SegmentedCodeCache
+ *      -XX:NonProfiledHotCodeHeapSize=50m
+ *      compiler.codecache.jmx.UsageThresholdExceededTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *      -XX:CompileCommand=compileonly,null::* -Djdk.test.lib.iterations=10
  *      -XX:-SegmentedCodeCache
  *      compiler.codecache.jmx.UsageThresholdExceededTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdExceededTest.java
@@ -39,6 +39,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing  -XX:-MethodFlushing
  *     -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.UsageThresholdExceededTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing  -XX:-MethodFlushing
+ *     -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.UsageThresholdExceededTest
  */

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdIncreasedTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdIncreasedTest.java
@@ -40,6 +40,12 @@
  *     -XX:CompileCommand=compileonly,null::*
  *     -XX:+SegmentedCodeCache
  *     compiler.codecache.jmx.UsageThresholdIncreasedTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing  -XX:-MethodFlushing
+ *     -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.UsageThresholdIncreasedTest
  */
 
 package compiler.codecache.jmx;

--- a/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdNotExceededTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/jmx/UsageThresholdNotExceededTest.java
@@ -39,6 +39,12 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
  *     -XX:CompileCommand=compileonly,null::*
+ *     -XX:+SegmentedCodeCache
+ *     -XX:NonProfiledHotCodeHeapSize=50m
+ *     compiler.codecache.jmx.UsageThresholdNotExceededTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *     -XX:+WhiteBoxAPI -XX:-UseCodeCacheFlushing -XX:-MethodFlushing
+ *     -XX:CompileCommand=compileonly,null::*
  *     -XX:-SegmentedCodeCache
  *     compiler.codecache.jmx.UsageThresholdNotExceededTest
  */

--- a/test/hotspot/jtreg/compiler/whitebox/AllocationCodeBlobTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/AllocationCodeBlobTest.java
@@ -38,6 +38,11 @@
  *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
  *                   -XX:+SegmentedCodeCache
  *                   compiler.whitebox.AllocationCodeBlobTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
+ *                   -XX:+SegmentedCodeCache
+ *                   -XX:NonProfiledHotCodeHeapSize=50m
+ *                   compiler.whitebox.AllocationCodeBlobTest
  */
 
 package compiler.whitebox;

--- a/test/hotspot/jtreg/compiler/whitebox/GetCodeHeapEntriesTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/GetCodeHeapEntriesTest.java
@@ -36,6 +36,10 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:+SegmentedCodeCache
  *                   compiler.whitebox.GetCodeHeapEntriesTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:+SegmentedCodeCache
+ *                   -XX:NonProfiledHotCodeHeapSize=50m
+ *                   compiler.whitebox.GetCodeHeapEntriesTest
  */
 
 package compiler.whitebox;

--- a/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/GetNMethodTest.java
@@ -34,6 +34,7 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -Xmixed -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:NonProfiledHotCodeHeapSize=0
  *                   -XX:+WhiteBoxAPI -XX:-UseCounterDecay
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
  *                   compiler.whitebox.GetNMethodTest

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -30,7 +30,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main MemoryTest 2 3
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 MemoryTest 2 3 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m MemoryTest 2 3 6
  */
 
 /*
@@ -42,7 +43,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main/othervm -XX:+UseZGC -XX:-ZGenerational MemoryTest 2 1
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 -XX:+UseZGC -XX:-ZGenerational MemoryTest 2 1 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m -XX:+UseZGC -XX:-ZGenerational MemoryTest 2 1 6
  */
 
 /*
@@ -54,7 +56,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main/othervm -XX:+UseZGC -XX:+ZGenerational MemoryTest 4 2
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 -XX:+UseZGC -XX:+ZGenerational MemoryTest 4 2 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m -XX:+UseZGC -XX:+ZGenerational MemoryTest 4 2 6
  */
 
 /*
@@ -66,7 +69,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main MemoryTest 2 1
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 MemoryTest 2 1 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m MemoryTest 2 1 6
  */
 
 /*
@@ -78,7 +82,8 @@
  * @author  Mandy Chung
  *
  * @modules jdk.management
- * @run main/othervm -XX:+UseG1GC MemoryTest 3 3
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=0 -XX:+UseG1GC MemoryTest 3 3 5
+ * @run main/othervm -XX:NonProfiledHotCodeHeapSize=10m -XX:+UseG1GC MemoryTest 3 3 6
  */
 
 /*
@@ -126,11 +131,13 @@ public class MemoryTest {
         expectedNumMgrs = expectedNumGCMgrs + 2;
 
         int expectedNumPools = Integer.valueOf(args[1]);
+        int expectedMaxNumPoolsOfNonHeap = Integer.valueOf(args[2]);
+
         expectedMinNumPools[HEAP] = expectedNumPools;
         expectedMaxNumPools[HEAP] = expectedNumPools;
 
         expectedMinNumPools[NONHEAP] = 2;
-        expectedMaxNumPools[NONHEAP] = 5;
+        expectedMaxNumPools[NONHEAP] = expectedMaxNumPoolsOfNonHeap;
 
         checkMemoryPools();
         checkMemoryManagers();

--- a/test/lib/jdk/test/whitebox/code/BlobType.java
+++ b/test/lib/jdk/test/whitebox/code/BlobType.java
@@ -38,8 +38,17 @@ public enum BlobType {
                     || type == BlobType.MethodProfiled;
         }
     },
+    // Execution level 4 (non-profiled hot) nmethods (without native nmethods)
+    MethodHotNonProfiled(1, "CodeHeap 'non-profiled hot nmethods'", "NonProfiledHotCodeHeapSize") {
+        @Override
+        public boolean allowTypeWhenOverflow(BlobType type) {
+            return super.allowTypeWhenOverflow(type)
+                    || type == BlobType.MethodNonProfiled
+                    || type == BlobType.MethodProfiled;
+        }
+    },
     // Execution level 2 and 3 (profiled) nmethods
-    MethodProfiled(1, "CodeHeap 'profiled nmethods'", "ProfiledCodeHeapSize") {
+    MethodProfiled(2, "CodeHeap 'profiled nmethods'", "ProfiledCodeHeapSize") {
         @Override
         public boolean allowTypeWhenOverflow(BlobType type) {
             return super.allowTypeWhenOverflow(type)
@@ -47,7 +56,7 @@ public enum BlobType {
         }
     },
     // Non-nmethods like Buffers, Adapters and Runtime Stubs
-    NonNMethod(2, "CodeHeap 'non-nmethods'", "NonNMethodCodeHeapSize") {
+    NonNMethod(3, "CodeHeap 'non-nmethods'", "NonNMethodCodeHeapSize") {
         @Override
         public boolean allowTypeWhenOverflow(BlobType type) {
             return super.allowTypeWhenOverflow(type)
@@ -56,7 +65,7 @@ public enum BlobType {
         }
     },
     // All types (No code cache segmentation)
-    All(3, "CodeCache", "ReservedCodeCacheSize");
+    All(4, "CodeCache", "ReservedCodeCacheSize");
 
     public final int id;
     public final String sizeOptionName;
@@ -98,6 +107,9 @@ public enum BlobType {
                 || whiteBox.getIntxVMFlag("TieredStopAtLevel") <= 1) {
             // there is no MethodProfiled in non tiered world or pure C1
             result.remove(MethodProfiled);
+        }
+        if (whiteBox.getUintxVMFlag("NonProfiledHotCodeHeapSize") == 0) {
+            result.remove(MethodHotNonProfiled);
         }
         return result;
     }


### PR DESCRIPTION
Summary:
1. Introduce a new code heap: divide a separated region "NonProfiledHotCodeHeap" from NonProfiled segment.
2. The size of NonProfiledHotCodeHeap is configurable.
3. Introduce a new CodeBlobType "MethodHotNonProfiled" corresponds to all methods inside the new region.
4. JIT could allocate nmethods into this separated region.
5. JIT could allocate itable/vtable stub in NonProfiledHotCodeHeap.
6. When "NonProfiledHotCodeHeap" is not enough to hold "hottest" methods anymore, allocate it into the original "NonProfiled" segment.
7. Code cache sweep support of "NonProfiledHotCodeHeap".
8. Introduce option "AllocIVtableStubInNonProfiledHotCodeHeap" to reorder itable/vtable stub.
9. Compiler Directive definition.
10. Method filter: Only matched C2 compiled "hottest" functions are placed into "NonProfiledHotCodeHeap".
11. Support "PrintCodeCache" ... options.
12. Log support for easy debug.
13. Add tests for the new code heap.
14. Turn "CompilerDirectivesFile" into a product option.

Testing: full jtreg

Reviewers: Kuai Wei, Zhang Quan

Issue: https://github.com/dragonwell-project/dragonwell21/issues/248