### PR TITLE
[JIT] Fix compilation issues about native acceleration

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -47,7 +47,6 @@
 #include "oops/generateOopMap.hpp"
 #include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
-#include "opto/nativeAcceleration.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/handles.inline.hpp"
@@ -57,6 +56,7 @@
 #include "ci/bcEscapeAnalyzer.hpp"
 #include "ci/ciTypeFlow.hpp"
 #include "oops/method.hpp"
+#include "opto/nativeAcceleration.hpp"
 #endif
 
 // ciMethod
@@ -106,9 +106,13 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   CompilerOracle::tag_blackhole_if_possible(h_m);
   _intrinsic_id       = h_m->intrinsic_id();
 
+#ifdef COMPILER2
   // Get entry of accelerated call.
   _accel_call_entry = NativeAccelTable::find(h_m->klass_name(), h_m->name(),
                                              h_m->signature());
+#else
+  _accel_call_entry = nullptr;
+#endif // COMPILER2
 
   ciEnv *env = CURRENT_ENV;
   if (env->jvmti_can_hotswap_or_post_breakpoint()) {

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -32,7 +32,6 @@
 #include "interpreter/bytecodes.hpp"
 #include "logging/logAsyncWriter.hpp"
 #include "memory/universe.hpp"
-#include "opto/nativeAcceleration.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
 #include "prims/downcallLinker.hpp"
@@ -51,6 +50,9 @@
 #if INCLUDE_JVMCI
 #include "jvmci/jvmci.hpp"
 #endif
+#ifdef COMPILER2
+#include "opto/nativeAcceleration.hpp"
+#endif // COMPILER2
 
 // Initialization done by VM thread in vm_init_globals()
 void check_ThreadShadow();
@@ -145,9 +147,11 @@ jint init_globals() {
   VMRegImpl::set_regName();  // need this before generate_stubs (for printing oop maps).
   SharedRuntime::generate_stubs();
 
+#ifdef COMPILER2
   if (!NativeAccelTable::init()) {
     return JNI_EINVAL;
   }
+#endif // COMPILER2
 
   return JNI_OK;
 }
@@ -204,7 +208,9 @@ void exit_globals() {
       SymbolTable::dump(tty);
       StringTable::dump(tty);
     }
+#ifdef COMPILER2
     NativeAccelTable::destroy();
+#endif // COMPILER2
     ostream_exit();
 #ifdef LEAK_SANITIZER
     {


### PR DESCRIPTION
Summary: When building a zero/minimal JDK, C2 will be disabled, causing some native acceleration code to fail to compile. Such code should be disabled using conditional compilation.

Testing: CI testing

Reviewers: kuaiwei, JoshuaZhuwj

Issue: https://github.com/dragonwell-project/dragonwell21/issues/252