### PR TITLE
[JIT] Update AI-Extension interface to simplify the implementation of extension units

### DIFF
--- a/src/hotspot/share/prims/aiext.cpp
+++ b/src/hotspot/share/prims/aiext.cpp
@@ -150,9 +150,9 @@ static int64_t get_field_offset(const char* klass, const char* method,
 }
 
 // Gets unit info, including feature name, version and parameter list.
-static aiext_result_t get_unit_info(const aiext_handle_t handle,
-                                    char* feature_buf, size_t feature_buf_size,
-                                    char* version_buf, size_t version_buf_size,
+static aiext_result_t get_unit_info(aiext_handle_t handle, char* feature_buf,
+                                    size_t feature_buf_size, char* version_buf,
+                                    size_t version_buf_size,
                                     char* param_list_buf,
                                     size_t param_list_buf_size) {
   // Find the given unit.

--- a/src/java.base/share/native/include/aiext.h
+++ b/src/java.base/share/native/include/aiext.h
@@ -53,10 +53,11 @@ typedef aiext_result_t (*aiext_init_t)(const aiext_env_t* env,
                                        aiext_handle_t handle);
 
 // Initializes AI-Extension unit after JVM's initialization.
-typedef aiext_result_t (*aiext_post_init_t)(const aiext_env_t* env);
+typedef aiext_result_t (*aiext_post_init_t)(const aiext_env_t* env,
+                                            aiext_handle_t handle);
 
 // Finalizes AI-Extension unit.
-typedef aiext_result_t (*aiext_finalize_t)(const aiext_env_t* env);
+typedef void (*aiext_finalize_t)(const aiext_env_t* env, aiext_handle_t handle);
 
 // Native acceleration provider.
 typedef void* (*aiext_naccel_provider_t)(const aiext_env_t* env,
@@ -114,10 +115,9 @@ struct aiext_env {
 
   // Gets unit info, including feature name, version and parameter list.
   // `handle` is provided by the JVM in the `aiext_init` function.
-  aiext_result_t (*get_unit_info)(const aiext_handle_t handle,
-                                  char* feature_buf, size_t feature_buf_size,
-                                  char* version_buf, size_t version_buf_size,
-                                  char* param_list_buf,
+  aiext_result_t (*get_unit_info)(aiext_handle_t handle, char* feature_buf,
+                                  size_t feature_buf_size, char* version_buf,
+                                  size_t version_buf_size, char* param_list_buf,
                                   size_t param_list_buf_size);
 
   // Get JNI interface

--- a/test/hotspot/jtreg/compiler/alibaba/TestAIExtension.java
+++ b/test/hotspot/jtreg/compiler/alibaba/TestAIExtension.java
@@ -82,7 +82,7 @@ public class TestAIExtension {
         // Duplicate entries in different units.
         testUnitLoadError("-XX:AIExtensionUnit=" + UNIT_NACCEL_1,
                           "-XX:AIExtensionUnit=" + UNIT_NACCEL2_1)
-            .shouldContain("Duplicate native acceleration entry found for");
+            .shouldContain("Duplicate native acceleration entry found");
 
         // Some units are invalid.
         testUnitParseError("-XX:AIExtensionUnit=" + UNIT_NACCEL_1,

--- a/test/hotspot/jtreg/compiler/alibaba/libAIExtTestInitError_1.c
+++ b/test/hotspot/jtreg/compiler/alibaba/libAIExtTestInitError_1.c
@@ -87,7 +87,8 @@ JNIEXPORT aiext_result_t JNICALL aiext_init(const aiext_env_t* env,
   return AIEXT_OK;
 }
 
-JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env) {
+JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env,
+                                                 aiext_handle_t handle) {
   if (post_init_error) {
     printf("Returning error in `aiext_post_init`...\n");
     return AIEXT_ERROR;

--- a/test/hotspot/jtreg/compiler/alibaba/libAIExtTestJNICall_1.c
+++ b/test/hotspot/jtreg/compiler/alibaba/libAIExtTestJNICall_1.c
@@ -32,7 +32,8 @@ JNIEXPORT aiext_result_t JNICALL aiext_init(const aiext_env_t* env,
   return AIEXT_OK;
 }
 
-JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env) {
+JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env,
+                                                 aiext_handle_t handle) {
   aiext_result_t result = AIEXT_ERROR;
   JNIEnv* jni = env->get_jni_env();
   if (jni == NULL) {

--- a/test/hotspot/jtreg/compiler/alibaba/libAIExtTestNaccel2_1.c
+++ b/test/hotspot/jtreg/compiler/alibaba/libAIExtTestNaccel2_1.c
@@ -33,7 +33,8 @@ JNIEXPORT aiext_result_t JNICALL aiext_init(const aiext_env_t* env,
   return AIEXT_OK;
 }
 
-JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env) {
+JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env,
+                                                 aiext_handle_t handle) {
   return env->register_naccel_provider("TestAIExtension$Launcher", "hello",
                                        "()V", "hello", hello, NULL);
 }

--- a/test/hotspot/jtreg/compiler/alibaba/libAIExtTestNaccel_1.c
+++ b/test/hotspot/jtreg/compiler/alibaba/libAIExtTestNaccel_1.c
@@ -85,7 +85,8 @@ JNIEXPORT aiext_result_t JNICALL aiext_init(const aiext_env_t* env,
   return AIEXT_OK;
 }
 
-JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env) {
+JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env,
+                                                 aiext_handle_t handle) {
 #define REPLACE_WITH_NATIVE(k, m, s, fn, f)                    \
   do {                                                         \
     aiext_result_t res;                                        \
@@ -122,7 +123,7 @@ JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env) {
   return AIEXT_OK;
 }
 
-JNIEXPORT aiext_result_t JNICALL aiext_finalize(const aiext_env_t* env) {
+JNIEXPORT void JNICALL aiext_finalize(const aiext_env_t* env,
+                                      aiext_handle_t handle) {
   printf("aiext_finalize\n");
-  return AIEXT_OK;
 }


### PR DESCRIPTION
Summary: The new interface always passes unit handle from JVM, making the unit's implementation simpler.

Testing: test/hotspot/jtreg/compiler/alibaba/TestAIExtension.java

Reviewers: kuaiwei, JoshuaZhuwj

Issue: https://github.com/dragonwell-project/dragonwell21/issues/266