### PR TITLE
[Misc] Avoid repeated addition of javaoptions in test cases

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -59,6 +59,7 @@ import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -235,7 +236,7 @@ public final class Utils {
      * @return The combination of JTReg test java options and user args.
      */
     public static String[] prependTestJavaOpts(String... userArgs) {
-        List<String> opts = new ArrayList<String>();
+        Set<String> opts = new LinkedHashSet<String>();
         Collections.addAll(opts, getTestJavaOpts());
         Collections.addAll(opts, userArgs);
         return opts.toArray(new String[0]);

--- a/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
+++ b/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.function.BooleanSupplier;
+import java.util.Set;
+import java.util.LinkedHashSet;
 
 import jdk.test.lib.management.InputArguments;
 import jdk.test.lib.process.ExitCode;
@@ -104,7 +106,7 @@ public abstract class CommandLineOptionTest {
             String wrongWarningMessage, ExitCode exitCode,
             boolean addTestVMOptions, String... options)
                     throws Throwable {
-        List<String> finalOptions = new ArrayList<>();
+        Set<String> finalOptions = new LinkedHashSet();
         if (addTestVMOptions) {
             Collections.addAll(finalOptions, InputArguments.getVmInputArgs());
             Collections.addAll(finalOptions, Utils.getTestJavaOpts());


### PR DESCRIPTION
Summary: As title

Testing: compiler/jvmci/events/JvmciShutdownEventTest.java
         jdk/test/lib/apps/LingeredAppTest.java
         sun/management/jmxremote/bootstrap/LocalManagementTest.java
         sun/management/jmxremote/bootstrap/PasswordFilePermissionTest.java
         sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
         sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.java
         sun/security/ssl/SSLSocketImpl/SSLSocketKeyLimit.java
         sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java

Reviewers: kuaiwei, MaxXSoft

Issue: https://github.com/dragonwell-project/dragonwell21/issues/269