### PR TITLE
[Backport] patches to fix jtreg test failure on aarch64

### DIFF
--- a/src/hotspot/cpu/arm/upcallLinker_arm.cpp
+++ b/src/hotspot/cpu/arm/upcallLinker_arm.cpp
@@ -25,7 +25,7 @@
 #include "prims/upcallLinker.hpp"
 #include "utilities/debug.hpp"
 
-address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
+address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
                                        BasicType* in_sig_bt, int total_in_args,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -36,6 +36,7 @@
 #include "oops/objArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/methodHandles.hpp"
+#include "prims/upcallLinker.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/continuationEntry.inline.hpp"
 #include "runtime/frame.inline.hpp"
@@ -4735,6 +4736,44 @@ class StubGenerator: public StubCodeGenerator {
 
 #endif // INCLUDE_JFR
 
+  // exception handler for upcall stubs
+  address generate_upcall_stub_exception_handler() {
+    StubCodeMark mark(this, "StubRoutines", "upcall stub exception handler");
+    address start = __ pc();
+
+    // Native caller has no idea how to handle exceptions,
+    // so we just crash here. Up to callee to catch exceptions.
+    __ verify_oop(R3_ARG1);
+    __ load_const_optimized(R12_scratch2, CAST_FROM_FN_PTR(uint64_t, UpcallLinker::handle_uncaught_exception), R0);
+    __ call_c(R12_scratch2);
+    __ should_not_reach_here();
+
+    return start;
+  }
+
+  // load Method* target of MethodHandle
+  // R3_ARG1 = jobject receiver
+  // R19_method = result Method*
+  address generate_upcall_stub_load_target() {
+
+    StubCodeMark mark(this, "StubRoutines", "upcall_stub_load_target");
+    address start = __ pc();
+
+    __ resolve_global_jobject(R3_ARG1, R22_tmp2, R23_tmp3, MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS);
+    // Load target method from receiver
+    __ load_heap_oop(R19_method, java_lang_invoke_MethodHandle::form_offset(), R3_ARG1,
+                     R22_tmp2, R23_tmp3, MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS, IS_NOT_NULL);
+    __ load_heap_oop(R19_method, java_lang_invoke_LambdaForm::vmentry_offset(), R19_method,
+                     R22_tmp2, R23_tmp3, MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS, IS_NOT_NULL);
+    __ load_heap_oop(R19_method, java_lang_invoke_MemberName::method_offset(), R19_method,
+                     R22_tmp2, R23_tmp3, MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS, IS_NOT_NULL);
+    __ ld(R19_method, java_lang_invoke_ResolvedMethodName::vmtarget_offset(), R19_method);
+    __ std(R19_method, in_bytes(JavaThread::callee_target_offset()), R16_thread); // just in case callee is deoptimized
+
+    __ blr();
+
+    return start;
+  }
 
   // Initialization
   void generate_initial_stubs() {
@@ -4820,6 +4859,9 @@ class StubGenerator: public StubCodeGenerator {
 
     // arraycopy stubs used by compilers
     generate_arraycopy_stubs();
+
+    StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
+    StubRoutines::_upcall_stub_load_target = generate_upcall_stub_load_target();
   }
 
   void generate_compiler_stubs() {

--- a/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "classfile/javaClasses.hpp"
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/upcallLinker.hpp"
@@ -115,10 +116,10 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
   __ block_comment("} restore_callee_saved_regs ");
 }
 
-static const int upcall_stub_code_base_size = 1536; // depends on GC (resolve_jobject)
+static const int upcall_stub_code_base_size = 1024;
 static const int upcall_stub_size_per_arg = 16; // arg save & restore + move
 
-address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
+address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
                                        BasicType* in_sig_bt, int total_in_args,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
@@ -231,13 +232,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   arg_shuffle.generate(_masm, as_VMStorage(callerSP), frame::native_abi_minframe_size, frame::jit_out_preserve_size, locs);
   __ block_comment("} argument shuffle");
 
-  __ block_comment("{ receiver ");
+  __ block_comment("{ load target ");
+  __ load_const_optimized(call_target_address, StubRoutines::upcall_stub_load_target(), R0);
   __ load_const_optimized(R3_ARG1, (intptr_t)receiver, R0);
-  __ resolve_jobject(R3_ARG1, tmp, R31, MacroAssembler::PRESERVATION_FRAME_LR_GP_FP_REGS); // kills R31
-  __ block_comment("} receiver ");
-
-  __ load_const_optimized(R19_method, (intptr_t)entry);
-  __ std(R19_method, in_bytes(JavaThread::callee_target_offset()), R16_thread);
+  __ mtctr(call_target_address);
+  __ bctrl(); // loads target Method* into R19_method
+  __ block_comment("} load target ");
 
   __ push_cont_fastpath();
 
@@ -318,24 +318,11 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 
   //////////////////////////////////////////////////////////////////////////////
 
-  __ block_comment("{ exception handler");
-
-  intptr_t exception_handler_offset = __ pc() - start;
-
-  // Native caller has no idea how to handle exceptions,
-  // so we just crash here. Up to callee to catch exceptions.
-  __ verify_oop(R3_ARG1);
-  __ load_const_optimized(call_target_address, CAST_FROM_FN_PTR(uint64_t, UpcallLinker::handle_uncaught_exception), R0);
-  __ call_c(call_target_address);
-  __ should_not_reach_here();
-
-  __ block_comment("} exception handler");
-
   _masm->flush();
 
 #ifndef PRODUCT
   stringStream ss;
-  ss.print("upcall_stub_%s", entry->signature()->as_C_string());
+  ss.print("upcall_stub_%s", signature->as_C_string());
   const char* name = _masm->code_string(ss.as_string());
 #else // PRODUCT
   const char* name = "upcall_stub";
@@ -346,7 +333,6 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   UpcallStub* blob
     = UpcallStub::create(name,
                          &buffer,
-                         exception_handler_offset,
                          receiver,
                          in_ByteSize(frame_data_offset));
 #ifndef ABI_ELFv2

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -37,6 +37,7 @@
 #include "oops/objArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/methodHandles.hpp"
+#include "prims/upcallLinker.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaThread.hpp"
@@ -3094,6 +3095,44 @@ class StubGenerator: public StubCodeGenerator {
 
   #endif // INCLUDE_JFR
 
+  // exception handler for upcall stubs
+  address generate_upcall_stub_exception_handler() {
+    StubCodeMark mark(this, "StubRoutines", "upcall stub exception handler");
+    address start = __ pc();
+
+    // Native caller has no idea how to handle exceptions,
+    // so we just crash here. Up to callee to catch exceptions.
+    __ verify_oop(Z_ARG1);
+    __ load_const_optimized(Z_R1_scratch, CAST_FROM_FN_PTR(uint64_t, UpcallLinker::handle_uncaught_exception));
+    __ call_c(Z_R1_scratch);
+    __ should_not_reach_here();
+
+    return start;
+  }
+
+  // load Method* target of MethodHandle
+  // Z_ARG1 = jobject receiver
+  // Z_method = Method* result
+  address generate_upcall_stub_load_target() {
+    StubCodeMark mark(this, "StubRoutines", "upcall_stub_load_target");
+    address start = __ pc();
+
+    __ resolve_global_jobject(Z_ARG1, Z_tmp_1, Z_tmp_2);
+      // Load target method from receiver
+    __ load_heap_oop(Z_method, Address(Z_ARG1, java_lang_invoke_MethodHandle::form_offset()),
+                    noreg, noreg, IS_NOT_NULL);
+    __ load_heap_oop(Z_method, Address(Z_method, java_lang_invoke_LambdaForm::vmentry_offset()),
+                    noreg, noreg, IS_NOT_NULL);
+    __ load_heap_oop(Z_method, Address(Z_method, java_lang_invoke_MemberName::method_offset()),
+                    noreg, noreg, IS_NOT_NULL);
+    __ z_lg(Z_method, Address(Z_method, java_lang_invoke_ResolvedMethodName::vmtarget_offset()));
+    __ z_stg(Z_method, Address(Z_thread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
+
+    __ z_br(Z_R14);
+
+    return start;
+  }
+
   void generate_initial_stubs() {
     // Generates all stubs and initializes the entry points.
 
@@ -3174,6 +3213,8 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::zarch::_nmethod_entry_barrier = generate_nmethod_entry_barrier();
     }
 
+    StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
+    StubRoutines::_upcall_stub_load_target = generate_upcall_stub_load_target();
   }
 
   void generate_compiler_stubs() {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -556,6 +556,10 @@ class StubGenerator: public StubCodeGenerator {
   // Slow path implementation for UseSecondarySupersTable.
   address generate_lookup_secondary_supers_table_slow_path_stub();
 
+  // shared exception handler for FFM upcall stubs
+  address generate_upcall_stub_exception_handler();
+  address generate_upcall_stub_load_target();
+
   void create_control_words();
 
   // Initialization

--- a/src/hotspot/cpu/x86/upcallLinker_x86_32.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_32.cpp
@@ -24,7 +24,7 @@
 #include "precompiled.hpp"
 #include "prims/upcallLinker.hpp"
 
-address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
+address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
                                        BasicType* in_sig_bt, int total_in_args,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -23,7 +23,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
-#include "code/codeBlob.hpp"
+#include "classfile/javaClasses.hpp"
 #include "code/codeBlob.hpp"
 #include "code/vmreg.inline.hpp"
 #include "compiler/disassembler.hpp"
@@ -165,10 +165,10 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
   __ block_comment("} restore_callee_saved_regs ");
 }
 
-static const int upcall_stub_code_base_size = 2048;
+static const int upcall_stub_code_base_size = 1200;
 static const int upcall_stub_size_per_arg = 16;
 
-address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
+address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
                                        BasicType* in_sig_bt, int total_in_args,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,
@@ -287,14 +287,10 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   arg_shuffle.generate(_masm, shuffle_reg, abi._shadow_space_bytes, 0, locs);
   __ block_comment("} argument shuffle");
 
-  __ block_comment("{ receiver ");
-  __ movptr(rscratch1, (intptr_t)receiver);
-  __ resolve_jobject(rscratch1, r15_thread, rscratch2);
-  __ movptr(j_rarg0, rscratch1);
-  __ block_comment("} receiver ");
-
-  __ mov_metadata(rbx, entry);
-  __ movptr(Address(r15_thread, JavaThread::callee_target_offset()), rbx); // just in case callee is deoptimized
+  __ block_comment("{ load target ");
+  __ movptr(j_rarg0, (intptr_t)receiver);
+  __ call(RuntimeAddress(StubRoutines::upcall_stub_load_target())); // puts target Method* in rbx
+  __ block_comment("} load target ");
 
   __ push_cont_fastpath();
 
@@ -365,30 +361,11 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 
   //////////////////////////////////////////////////////////////////////////////
 
-  __ block_comment("{ exception handler");
-
-  intptr_t exception_handler_offset = __ pc() - start;
-
-  // TODO: this is always the same, can we bypass and call handle_uncaught_exception directly?
-
-  // native caller has no idea how to handle exceptions
-  // we just crash here. Up to callee to catch exceptions.
-  __ verify_oop(rax);
-  __ vzeroupper();
-  __ mov(c_rarg0, rax);
-  __ andptr(rsp, -StackAlignmentInBytes); // align stack as required by ABI
-  __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows (not really needed)
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, UpcallLinker::handle_uncaught_exception)));
-  __ should_not_reach_here();
-
-  __ block_comment("} exception handler");
-
   _masm->flush();
-
 
 #ifndef PRODUCT
   stringStream ss;
-  ss.print("upcall_stub_%s", entry->signature()->as_C_string());
+  ss.print("upcall_stub_%s", signature->as_C_string());
   const char* name = _masm->code_string(ss.freeze());
 #else // PRODUCT
   const char* name = "upcall_stub";
@@ -399,7 +376,6 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   UpcallStub* blob
     = UpcallStub::create(name,
                          &buffer,
-                         exception_handler_offset,
                          receiver,
                          in_ByteSize(frame_data_offset));
 

--- a/src/hotspot/cpu/zero/upcallLinker_zero.cpp
+++ b/src/hotspot/cpu/zero/upcallLinker_zero.cpp
@@ -24,7 +24,7 @@
 #include "precompiled.hpp"
 #include "prims/upcallLinker.hpp"
 
-address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
+address UpcallLinker::make_upcall_stub(jobject mh, Symbol* signature,
                                        BasicType* in_sig_bt, int total_in_args,
                                        BasicType* out_sig_bt, int total_out_args,
                                        BasicType ret_type,

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -642,13 +642,10 @@ class UpcallLinker;
 class UpcallStub: public RuntimeBlob {
   friend class UpcallLinker;
  private:
-  intptr_t _exception_handler_offset;
   jobject _receiver;
   ByteSize _frame_data_offset;
 
-  UpcallStub(const char* name, CodeBuffer* cb, int size,
-                     intptr_t exception_handler_offset,
-                     jobject receiver, ByteSize frame_data_offset);
+  UpcallStub(const char* name, CodeBuffer* cb, int size, jobject receiver, ByteSize frame_data_offset);
 
   void* operator new(size_t s, unsigned size) throw();
 
@@ -663,13 +660,10 @@ class UpcallStub: public RuntimeBlob {
   FrameData* frame_data_for_frame(const frame& frame) const;
  public:
   // Creation
-  static UpcallStub* create(const char* name, CodeBuffer* cb,
-                            intptr_t exception_handler_offset,
-                            jobject receiver, ByteSize frame_data_offset);
+  static UpcallStub* create(const char* name, CodeBuffer* cb, jobject receiver, ByteSize frame_data_offset);
 
   static void free(UpcallStub* blob);
 
-  address exception_handler() { return code_begin() + _exception_handler_offset; }
   jobject receiver() { return _receiver; }
 
   JavaFrameAnchor* jfa_for_frame(const frame& frame) const;

--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -22,7 +22,7 @@
  */
 
 #include "precompiled.hpp"
-#include "classfile/javaClasses.hpp"
+#include "classfile/javaClasses.inline.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "compiler/compilationPolicy.hpp"
@@ -132,11 +132,10 @@ void UpcallLinker::on_exit(UpcallStub::FrameData* context) {
 }
 
 void UpcallLinker::handle_uncaught_exception(oop exception) {
-  ResourceMark rm;
-  // Based on CATCH macro
   tty->print_cr("Uncaught exception:");
-  exception->print();
-  ShouldNotReachHere();
+  Handle exception_h(Thread::current(), exception);
+  java_lang_Throwable::print_stack_trace(exception_h, tty);
+  fatal("Unrecoverable uncaught exception encountered");
 }
 
 JVM_ENTRY(jlong, UL_MakeUpcallStub(JNIEnv *env, jclass unused, jobject mh, jobject abi, jobject conv,
@@ -144,31 +143,25 @@ JVM_ENTRY(jlong, UL_MakeUpcallStub(JNIEnv *env, jclass unused, jobject mh, jobje
   ResourceMark rm(THREAD);
   Handle mh_h(THREAD, JNIHandles::resolve(mh));
   jobject mh_j = JNIHandles::make_global(mh_h);
+  oop type = java_lang_invoke_MethodHandle::type(mh_h());
 
-  oop lform = java_lang_invoke_MethodHandle::form(mh_h());
-  oop vmentry = java_lang_invoke_LambdaForm::vmentry(lform);
-  Method* entry = java_lang_invoke_MemberName::vmtarget(vmentry);
-  const methodHandle mh_entry(THREAD, entry);
-
-  assert(entry->method_holder()->is_initialized(), "no clinit barrier");
-  CompilationPolicy::compile_if_required(mh_entry, CHECK_0);
-
-  assert(entry->is_static(), "static only");
   // Fill in the signature array, for the calling-convention call.
-  const int total_out_args = entry->size_of_parameters();
-  assert(total_out_args > 0, "receiver arg");
+  const int total_out_args = java_lang_invoke_MethodType::ptype_slot_count(type) + 1; // +1 for receiver
 
+  bool create_new = true;
+  TempNewSymbol signature = java_lang_invoke_MethodType::as_signature(type, create_new);
   BasicType* out_sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_out_args);
   BasicType ret_type;
   {
     int i = 0;
-    SignatureStream ss(entry->signature());
+    out_sig_bt[i++] = T_OBJECT; // receiver MH
+    SignatureStream ss(signature);
     for (; !ss.at_return_type(); ss.next()) {
       out_sig_bt[i++] = ss.type();  // Collect remaining bits of signature
       if (ss.type() == T_LONG || ss.type() == T_DOUBLE)
         out_sig_bt[i++] = T_VOID;   // Longs & doubles take 2 Java slots
     }
-    assert(i == total_out_args, "");
+    assert(i == total_out_args, "%d != %d", i, total_out_args);
     ret_type = ss.type();
   }
   // skip receiver
@@ -176,7 +169,7 @@ JVM_ENTRY(jlong, UL_MakeUpcallStub(JNIEnv *env, jclass unused, jobject mh, jobje
   int total_in_args = total_out_args - 1;
 
   return (jlong) UpcallLinker::make_upcall_stub(
-    mh_j, entry, in_sig_bt, total_in_args, out_sig_bt, total_out_args, ret_type, abi, conv, needs_return_buffer, checked_cast<int>(ret_buf_size));
+    mh_j, signature, in_sig_bt, total_in_args, out_sig_bt, total_out_args, ret_type, abi, conv, needs_return_buffer, checked_cast<int>(ret_buf_size));
 JVM_END
 
 #define CC (char*)  /*cast a literal from (const char*)*/

--- a/src/hotspot/share/prims/upcallLinker.hpp
+++ b/src/hotspot/share/prims/upcallLinker.hpp
@@ -32,18 +32,20 @@ class JavaThread;
 
 class UpcallLinker {
 private:
-  static void handle_uncaught_exception(oop exception);
   static JavaThread* maybe_attach_and_get_thread();
 
   static JavaThread* on_entry(UpcallStub::FrameData* context);
   static void on_exit(UpcallStub::FrameData* context);
 public:
-  static address make_upcall_stub(jobject mh, Method* entry,
+  static address make_upcall_stub(jobject mh, Symbol* signature,
                                   BasicType* in_sig_bt, int total_in_args,
                                   BasicType* out_sig_bt, int total_out_args,
                                   BasicType ret_type,
                                   jobject jabi, jobject jconv,
                                   bool needs_return_buffer, int ret_buf_size);
+
+  // public for stubGenerator
+  static void handle_uncaught_exception(oop exception);
 };
 
 #endif // SHARE_VM_PRIMS_UPCALLLINKER_HPP

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -724,6 +724,8 @@ void frame::print_on_error(outputStream* st, char* buf, int buflen, bool verbose
       st->print("v  ~MethodHandlesAdapterBlob " PTR_FORMAT, p2i(pc()));
     } else if (_cb->is_uncommon_trap_stub()) {
       st->print("v  ~UncommonTrapBlob " PTR_FORMAT, p2i(pc()));
+    } else if (_cb->is_upcall_stub()) {
+      st->print("v  ~UpcallStub::%s " PTR_FORMAT, _cb->name(), p2i(pc()));
     } else {
       st->print("v  blob " PTR_FORMAT, p2i(pc()));
     }
@@ -1120,6 +1122,19 @@ void frame::oops_entry_do(OopClosure* f, const RegisterMap* map) const {
   entry_frame_call_wrapper()->oops_do(f);
 }
 
+void frame::oops_upcall_do(OopClosure* f, const RegisterMap* map) const {
+  assert(map != nullptr, "map must be set");
+  if (map->include_argument_oops()) {
+    // Upcall stubs call a MethodHandle impl method of which only the receiver
+    // is ever an oop.
+    // Currently we should not be able to get here, since there are no
+    // safepoints in the one resolve stub we can get into (handle_wrong_method)
+    // Leave this here as a trap in case we ever do:
+    ShouldNotReachHere(); // not implemented
+  }
+  _cb->as_upcall_stub()->oops_do(f, *this);
+}
+
 bool frame::is_deoptimized_frame() const {
   assert(_deopt_state != unknown, "not answerable");
   if (_deopt_state == is_deoptimized) {
@@ -1151,7 +1166,7 @@ void frame::oops_do_internal(OopClosure* f, CodeBlobClosure* cf,
   } else if (is_entry_frame()) {
     oops_entry_do(f, map);
   } else if (is_upcall_stub_frame()) {
-    _cb->as_upcall_stub()->oops_do(f, *this);
+    oops_upcall_do(f, map);
   } else if (CodeCache::contains(pc())) {
     oops_code_blob_do(f, cf, df, derived_mode, map);
   } else {

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -447,6 +447,7 @@ class frame {
                         const RegisterMap* map, bool use_interpreter_oop_map_cache) const;
 
   void oops_entry_do(OopClosure* f, const RegisterMap* map) const;
+  void oops_upcall_do(OopClosure* f, const RegisterMap* map) const;
   void oops_code_blob_do(OopClosure* f, CodeBlobClosure* cf,
                          DerivedOopClosure* df, DerivedPointerIterationMode derived_mode,
                          const RegisterMap* map) const;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -520,7 +520,7 @@ address SharedRuntime::raw_exception_handler_for_return_address(JavaThread* curr
     return StubRoutines::catch_exception_entry();
   }
   if (blob != nullptr && blob->is_upcall_stub()) {
-    return ((UpcallStub*)blob)->exception_handler();
+    return StubRoutines::upcall_stub_exception_handler();
   }
   // Interpreted code
   if (Interpreter::contains(return_address)) {

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -192,6 +192,8 @@ JFR_ONLY(address StubRoutines::_jfr_return_lease = nullptr;)
 address StubRoutines::_lookup_secondary_supers_table_slow_path_stub = nullptr;
 address StubRoutines::_lookup_secondary_supers_table_stubs[Klass::SECONDARY_SUPERS_TABLE_SIZE] = { nullptr };
 
+address StubRoutines::_upcall_stub_exception_handler = nullptr;
+address StubRoutines::_upcall_stub_load_target = nullptr;
 
 // Initialization
 //

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -271,6 +271,8 @@ class StubRoutines: AllStatic {
 
   static address _lookup_secondary_supers_table_stubs[];
   static address _lookup_secondary_supers_table_slow_path_stub;
+  static address _upcall_stub_exception_handler;
+  static address _upcall_stub_load_target;
 
  public:
   // Initialization/Testing
@@ -477,6 +479,16 @@ class StubRoutines: AllStatic {
   static address lookup_secondary_supers_table_slow_path_stub() {
     assert(_lookup_secondary_supers_table_slow_path_stub != nullptr, "not implemented");
     return _lookup_secondary_supers_table_slow_path_stub;
+  }
+
+  static address upcall_stub_exception_handler() {
+    assert(_upcall_stub_exception_handler != nullptr, "not implemented");
+    return _upcall_stub_exception_handler;
+  }
+
+  static address upcall_stub_load_target() {
+    assert(_upcall_stub_load_target != nullptr, "not implemented");
+    return _upcall_stub_load_target;
   }
 
   static address select_fill_function(BasicType t, bool aligned, const char* &name);

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -389,7 +389,8 @@ jdk_svc = \
 jdk_foreign = \
     java/foreign \
     jdk/internal/reflect/CallerSensitive/CheckCSMs.java \
-    -java/foreign/TestMatrix.java
+    -java/foreign/TestMatrix.java \
+    -java/foreign/TestUpcallStress.java
 
 jdk_vector = \
     jdk/incubator/vector
@@ -671,3 +672,4 @@ jdk_containers_extended = \
 jdk_core_no_security = \
    :jdk_core \
    -:jdk_security
+

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires jdk.foreign.linker != "FALLBACK"
+ * @requires (os.arch == "aarch64" | os.arch=="riscv64") & os.name == "Linux"
+ * @requires os.maxMemory > 4G
+ * @modules java.base/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
+ * @bug 8337753
+ *
+ * @run testng/othervm/timeout=3200
+ *   -Xcheck:jni
+ *   -XX:+IgnoreUnrecognizedVMOptions
+ *   -XX:-VerifyDependencies
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Dgenerator.sample.factor=17
+ *   TestUpcallStress
+ */
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
+
+public class TestUpcallStress extends TestUpcallBase {
+
+    static {
+        System.loadLibrary("TestUpcall");
+    }
+
+    @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
+    public void testUpcallsStress(int count, String fName, Ret ret, List<ParamType> paramTypes,
+                                  List<StructFieldType> fields) throws Throwable {
+        ExecutorService executor = Executors.newFixedThreadPool(16);
+        for (int threadIdx = 0; threadIdx < 16; threadIdx++) {
+            executor.submit(() -> {
+                for (int iter = 0; iter < 10000; iter++) {
+                    List<Consumer<Object>> returnChecks = new ArrayList<>();
+                    List<Consumer<Object>> argChecks = new ArrayList<>();
+                    MemorySegment addr = findNativeOrThrow(fName);
+                    try (Arena arena = Arena.ofConfined()) {
+                        FunctionDescriptor descriptor = function(ret, paramTypes, fields);
+                        MethodHandle mh = downcallHandle(LINKER, addr, arena, descriptor);
+                        AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+                        Object[] args = makeArgs(capturedArgs, arena, descriptor, returnChecks, argChecks, 0);
+
+                        Object res = mh.invokeWithArguments(args);
+
+                        if (ret == Ret.NON_VOID) {
+                            returnChecks.forEach(c -> c.accept(res));
+                        }
+
+                        Object[] capturedArgsArr = capturedArgs.get();
+                        for (int i = 0; i < capturedArgsArr.length; i++) {
+                            argChecks.get(i).accept(capturedArgsArr[i]);
+                        }
+                    } catch (Throwable ex) {
+                        throw new AssertionError(ex);
+                    }
+                }
+            });
+        }
+        // This shutdownNow is 'wrong', since it doesn't wait for tasks to terminate,
+        // but it seems to be the only way to reproduce the race of JDK-8337753
+        executor.shutdownNow();
+    }
+}


### PR DESCRIPTION
Summary: backport
  8318609: Upcall stubs should be smaller
  8337753: Target class of upcall stub may be unloaded

Reviewers: jiawei.tjw, joshua.zwj

Testing: jtreg

Issue: #281