### PR TITLE
[JIT] Introduce AI-Extension API version 2

### DIFF
--- a/src/hotspot/share/opto/aiExtension.cpp
+++ b/src/hotspot/share/opto/aiExtension.cpp
@@ -291,14 +291,13 @@ void* AccelCallEntry::get_native_func() const {
 }
 
 // Adds the given native acceleration unit to table.
+// Returns `false` if the unit is already added.
 static bool add_unit(AIExtUnit* unit) {
   assert(loaded_units != nullptr, "must be initialized");
   bool found;
   int index =
       loaded_units->find_sorted<AIExtUnit*, AIExtUnit::compare>(unit, found);
   if (found) {
-    tty->print_cr("Error: Duplicate AI-Extension unit `%s_%s`", unit->feature(),
-                  unit->version());
     return false;
   }
   loaded_units->insert_before(index, unit);
@@ -341,9 +340,9 @@ bool AIExt::init() {
 
     // Add to the table.
     if (!add_unit(unit)) {
+      warning("Ignoring duplicate AI-Extension unit `%s_%s`", unit->feature(),
+              unit->version());
       delete unit;
-      os::free(args);
-      return false;
     }
 
     arg = p + 1;
@@ -407,6 +406,13 @@ bool AIExt::add_entry(const char* klass, const char* method,
     return false;
   }
 
+  if ((int)strlen(klass) > Symbol::max_length() ||
+      (int)strlen(method) > Symbol::max_length() ||
+      (int)strlen(signature) > Symbol::max_length()) {
+    log_error(aiext)("Symbol is too long");
+    return false;
+  }
+
   // Create symbols.
   Symbol* klass_sym = SymbolTable::new_permanent_symbol(klass);
   Symbol* method_sym = SymbolTable::new_permanent_symbol(method);
@@ -427,8 +433,9 @@ bool AIExt::add_entry(const char* klass, const char* method,
   }
 
   // Create entry and add to table.
-  AccelCallEntry* entry = new AccelCallEntry(
-      klass_sym, method_sym, sig_sym, native_func_name, func_or_data, provider);
+  AccelCallEntry* entry =
+      new AccelCallEntry(klass_sym, method_sym, sig_sym,
+                         os::strdup(native_func_name), func_or_data, provider);
   accel_table->insert_before(index, entry);
   return true;
 }
@@ -568,16 +575,7 @@ static void fill_type_field(const Type**& field, ciType* type, bool is_arg,
       *field++ = TypeInstPtr::BOTTOM;
       break;
     case T_ARRAY:
-      if (is_arg) {
-        // Base pointer does not point to a Java object,
-        // so we use raw pointer here.
-        *field++ = TypeRawPtr::BOTTOM;
-        // Append an integer for array only when it's an argument.
-        *field++ = TypeInt::INT;
-      } else {
-        // We expect the function returns a Java array.
-        *field++ = TypeOopPtr::BOTTOM;
-      }
+      *field++ = TypeOopPtr::BOTTOM;
       break;
     case T_VOID:
       assert(!is_arg, "void argument?");
@@ -594,14 +592,7 @@ JVMState* AccelCallGenerator::generate(JVMState* jvms) {
   ciSignature* signature = callee->signature();
 
   // Get number of stack slots required for arguments.
-  // Array arguments should be passed to native functions as tuples of base
-  // pointer and length (int), so they require an additional slot.
   int arg_size = callee->arg_size();
-  for (int i = 0; i < signature->count(); ++i) {
-    if (signature->type_at(i)->basic_type() == T_ARRAY) {
-      ++arg_size;
-    }
-  }
 
   // Create argument types.
   bool has_fp_type = false;
@@ -630,14 +621,13 @@ JVMState* AccelCallGenerator::generate(JVMState* jvms) {
   const TypeFunc* func_type = TypeFunc::make(args_tuple, ret_tuple);
 
   // Create call node.
-  void* native_func = callee->accel_call_entry()->get_native_func();
   const char* name = callee->accel_call_entry()->native_func_name();
   CallNode* call;
   if (has_fp_type) {
-    call = new CallLeafNode(func_type, (address)native_func, name,
+    call = new CallLeafNode(func_type, (address)_native_func, name,
                             TypePtr::BOTTOM);
   } else {
-    call = new CallLeafNoFPNode(func_type, (address)native_func, name,
+    call = new CallLeafNoFPNode(func_type, (address)_native_func, name,
                                 TypePtr::BOTTOM);
   }
 
@@ -650,31 +640,16 @@ JVMState* AccelCallGenerator::generate(JVMState* jvms) {
     call->init_req(req_index++, kit.argument(arg_index++));
   }
   for (int i = 0; i < signature->count(); ++i) {
-    ciType* arg_type = signature->type_at(i);
+    // Push argument.
     Node* arg = kit.argument(arg_index++);
-    switch (arg_type->basic_type()) {
-      case T_ARRAY: {
-        // Pass array's base address and length to the native function.
-        ciType* elem_type = arg_type->as_array_klass()->element_type();
-        BasicType elem_bt = elem_type->basic_type();
-        Node* addr = kit.array_element_address(arg, kit.intcon(0), elem_bt);
-        Node* len = kit.load_array_length(arg);
-        call->init_req(req_index++, addr);
-        call->init_req(req_index++, len);
-        break;
-      }
-      case T_DOUBLE:
-      case T_LONG: {
-        call->init_req(req_index++, arg);
-        Node* top = kit.argument(arg_index++);
-        assert(top == kit.top(), "must be top");
-        call->init_req(req_index++, top);
-        break;
-      }
-      default: {
-        call->init_req(req_index++, arg);
-        break;
-      }
+    call->init_req(req_index++, arg);
+
+    // Push top for double/long types.
+    BasicType bt = signature->type_at(i)->basic_type();
+    if (bt == T_DOUBLE || bt == T_LONG) {
+      Node* top = kit.argument(arg_index++);
+      assert(top == kit.top(), "must be top");
+      call->init_req(req_index++, top);
     }
   }
 

--- a/src/hotspot/share/opto/aiExtension.hpp
+++ b/src/hotspot/share/opto/aiExtension.hpp
@@ -133,6 +133,12 @@ class AccelCallEntry : public CHeapObj<mtCompiler> {
         _func_or_data(func_or_data),
         _provider(provider) {}
 
+  ~AccelCallEntry() {
+    if (_native_func_name != nullptr) {
+      os::free((void*)_native_func_name);
+    }
+  }
+
  public:
   // Returns the native function pointer.
   // This method may call the provider function.
@@ -177,10 +183,13 @@ class AIExt : public AllStatic {
 class AccelCallGenerator : public InlineCallGenerator {
  private:
   bool _is_virtual;
+  void* _native_func;
 
  public:
-  AccelCallGenerator(ciMethod* m, bool is_virtual)
-      : InlineCallGenerator(m), _is_virtual(is_virtual) {}
+  AccelCallGenerator(ciMethod* m, bool is_virtual, void* native_func)
+      : InlineCallGenerator(m),
+        _is_virtual(is_virtual),
+        _native_func(native_func) {}
 
   bool is_virtual() const override { return _is_virtual; }
 

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -129,7 +129,10 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
   // Handle native acceleration before intrinsic, to make sure we can always
   // call the replaced version of the current method.
   if (callee->accel_call_entry() != nullptr) {
-    return new AccelCallGenerator(callee, call_does_dispatch);
+    void* native_func = callee->accel_call_entry()->get_native_func();
+    if (native_func != nullptr) {
+      return new AccelCallGenerator(callee, call_does_dispatch, native_func);
+    }
   }
 #endif // INCLUDE_AIEXT
 

--- a/test/hotspot/jtreg/compiler/alibaba/libAIExtTestNaccel_1.c
+++ b/test/hotspot/jtreg/compiler/alibaba/libAIExtTestNaccel_1.c
@@ -21,11 +21,99 @@
  * questions.
  */
 
+#include <assert.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
 #include "aiext.h"
+
+static size_t obj_array_len_offset, obj_array_data_offset, obj_array_elem_size;
+static size_t byte_array_len_offset, byte_array_data_offset,
+    byte_array_elem_size;
+static size_t int_array_len_offset, int_array_data_offset, int_array_elem_size;
+
+static uint32_t narrow_null;
+static uintptr_t narrow_base;
+static size_t narrow_shift;
+
+static int offset_x_int, offset_x_double, offset_strs, offset_string_value;
+
+static void *addr_static_int, *addr_static_enum, *addr_test_enum_a,
+    *addr_test_enum_b, *addr_test_enum_c;
+
+static void* native_provider(const aiext_env_t* env,
+                             const char* native_func_name, void* data) {
+  offset_x_int =
+      env->get_field_offset("TestAIExtension$Launcher", "x_int", "I");
+  offset_x_double =
+      env->get_field_offset("TestAIExtension$Launcher", "x_double", "D");
+  offset_strs = env->get_field_offset("TestAIExtension$Launcher", "strs",
+                                      "[Ljava/lang/String;");
+  offset_string_value =
+      env->get_field_offset("java/lang/String", "value", "[B");
+  addr_static_int =
+      env->get_static_field_addr("TestAIExtension$Launcher", "static_int", "I");
+  addr_static_enum =
+      env->get_static_field_addr("TestAIExtension$Launcher", "static_enum",
+                                 "LTestAIExtension$Launcher$TestEnum;");
+  addr_test_enum_a =
+      env->get_static_field_addr("TestAIExtension$Launcher$TestEnum", "A",
+                                 "LTestAIExtension$Launcher$TestEnum;");
+  addr_test_enum_b =
+      env->get_static_field_addr("TestAIExtension$Launcher$TestEnum", "B",
+                                 "LTestAIExtension$Launcher$TestEnum;");
+  addr_test_enum_c =
+      env->get_static_field_addr("TestAIExtension$Launcher$TestEnum", "C",
+                                 "LTestAIExtension$Launcher$TestEnum;");
+  printf(
+      "Compiling `%s`, offset_x_int=%d, offset_x_double=%d, "
+      "offset_strs=%d, offset_string_value=%d, addr_static_int=%p, "
+      "addr_static_enum=%p, addr_test_enum_a=%p, addr_test_enum_b=%p, "
+      "addr_test_enum_c=%p\n",
+      native_func_name, offset_x_int, offset_x_double, offset_strs,
+      offset_string_value, addr_static_int, addr_static_enum, addr_test_enum_a,
+      addr_test_enum_b, addr_test_enum_c);
+  if (offset_x_int < 0 || offset_x_double < 0 || offset_strs < 0 ||
+      offset_string_value < 0 || addr_static_int == NULL ||
+      addr_static_enum == NULL || addr_test_enum_a == NULL ||
+      addr_test_enum_b == NULL || addr_test_enum_c == NULL) {
+    return NULL;
+  }
+  return data;
+}
+
+static void* get_raw_pointer(void* oop) {
+  if (obj_array_elem_size < sizeof(void*)) {
+    // Narrow oop layout.
+    uint32_t narrow = *(uint32_t*)oop;
+    if (narrow == narrow_null) {
+      return NULL;
+    }
+    return (void*)(narrow_base + ((uintptr_t)narrow << narrow_shift));
+  } else {
+    return *(void**)oop;
+  }
+}
+
+static bool is_oop_eq(const void* lhs, const void* rhs) {
+  if (obj_array_elem_size < sizeof(void*)) {
+    // Narrow oop layout.
+    return *(const uint32_t*)lhs == *(const uint32_t*)rhs;
+  } else {
+    return *(void* const*)lhs == *(void* const*)rhs;
+  }
+}
+
+static void set_oop(void* dst, const void* oop) {
+  if (obj_array_elem_size < sizeof(void*)) {
+    // Narrow oop layout.
+    *(uint32_t*)dst = *(const uint32_t*)oop;
+  } else {
+    *(void**)dst = *(void* const*)oop;
+  }
+}
 
 // For ()V static method.
 static void hello() { printf("Hello from native library!\n"); }
@@ -49,8 +137,11 @@ static void hello_double(double d) {
 }
 
 // For ([B)V static method.
-static void hello_bytes(const int8_t* chars, int32_t len) {
-  printf("Hello, I got %.*s (bytes)!\n", len, chars);
+static void hello_bytes(const void* chars) {
+  int32_t len = *(const int32_t*)((const char*)chars + byte_array_len_offset);
+  char* cs = (char*)chars + byte_array_data_offset;
+  assert(byte_array_elem_size == sizeof(char) && "unexpected byte size");
+  printf("Hello, I got %.*s (bytes)!\n", len, cs);
 }
 
 // For (Ljava/lang/Object;)V static method.
@@ -73,11 +164,86 @@ static double add_doubles(double a, double b) { return a + b; }
 
 // Adds two integer arrays, updates the first array in-place.
 // For ([I[I)V method.
-static void add_arrays(const void* this, int32_t* a, int32_t a_len, int32_t* b,
-                       int32_t b_len) {
+static void add_arrays(const void* this, void* a, const void* b) {
+  int32_t a_len = *(int32_t*)((char*)a + int_array_len_offset);
+  int32_t b_len = *(int32_t*)((char*)b + int_array_len_offset);
   for (int i = 0; i < a_len && i < b_len; i++) {
-    a[i] += b[i];
+    int32_t* pa =
+        (int32_t*)((char*)a + int_array_data_offset + i * int_array_elem_size);
+    int32_t* pb =
+        (int32_t*)((char*)b + int_array_data_offset + i * int_array_elem_size);
+    *pa += *pb;
   }
+}
+
+// Adds the given integer to object's field.
+// For (I)V method.
+static void add_to_int(void* this, int32_t i) {
+  assert(offset_x_int > 0 && "Invalid field offset");
+  int32_t* x_int = (int32_t*)((char*)this + offset_x_int);
+  *x_int += i;
+}
+
+// Adds the given double to object's field.
+// For (D)V method.
+static void add_to_double(void* this, double d) {
+  assert(offset_x_double > 0 && "Invalid field offset");
+  double* x_double = (double*)((char*)this + offset_x_double);
+  *x_double += d;
+}
+
+// Reads the string array and prints it out.
+// For ()V method.
+static void read_strs(void* this) {
+  assert(offset_strs > 0 && offset_string_value > 0 && "Invalid field offset");
+
+  // Get pointer to the string array.
+  void* strs = get_raw_pointer((char*)this + offset_strs);
+  assert(strs != NULL && "Invalid string array");
+
+  // Traverse the string array.
+  int32_t strs_len = *(int32_t*)((char*)strs + obj_array_len_offset);
+  for (int32_t i = 0; i < strs_len; i++) {
+    void* str = get_raw_pointer((char*)strs + obj_array_data_offset +
+                                i * obj_array_elem_size);
+    assert(str != NULL && "Invalid string");
+
+    // Get pointer to the string's byte array.
+    void* value = get_raw_pointer((char*)str + offset_string_value);
+    assert(value != NULL && "Invalid string's byte array");
+
+    // Print the string's byte array.
+    int32_t value_len = *(int32_t*)((char*)value + byte_array_len_offset);
+    for (int32_t j = 0; j < value_len; j++) {
+      char c =
+          *((char*)value + byte_array_data_offset + j * byte_array_elem_size);
+      putchar(c);
+    }
+    putchar('\n');
+  }
+}
+
+// Adds the given integer to static field.
+// For (I)V method.
+static void add_to_static_int(int32_t i) {
+  assert(addr_static_int != NULL && "Invalid static field address");
+  *(int32_t*)addr_static_int += i;
+}
+
+// Checks the static enum field and updates it.
+// For ()V method.
+static void check_static_enum() {
+  assert(addr_static_enum != NULL && "Invalid static field address");
+  if (is_oop_eq(addr_static_enum, addr_test_enum_a)) {
+    printf("A\n");
+  } else if (is_oop_eq(addr_static_enum, addr_test_enum_b)) {
+    printf("B\n");
+  } else if (is_oop_eq(addr_static_enum, addr_test_enum_c)) {
+    printf("C\n");
+  } else {
+    printf("Unknown\n");
+  }
+  set_oop(addr_static_enum, addr_test_enum_b);
 }
 
 JNIEXPORT aiext_result_t JNICALL aiext_init(const aiext_env_t* env,
@@ -87,39 +253,74 @@ JNIEXPORT aiext_result_t JNICALL aiext_init(const aiext_env_t* env,
 
 JNIEXPORT aiext_result_t JNICALL aiext_post_init(const aiext_env_t* env,
                                                  aiext_handle_t handle) {
-#define REPLACE_WITH_NATIVE(k, m, s, fn, f)                    \
-  do {                                                         \
-    aiext_result_t res;                                        \
-    res = env->register_naccel_provider(k, m, s, fn, f, NULL); \
-    if (res != AIEXT_OK) {                                     \
-      return res;                                              \
-    }                                                          \
+  // Get array layout.
+  aiext_result_t res;
+  res = env->get_array_layout(AIEXT_TYPE_OBJECT, &obj_array_len_offset,
+                              &obj_array_data_offset, &obj_array_elem_size);
+  if (res != AIEXT_OK) {
+    return res;
+  }
+  res = env->get_array_layout(AIEXT_TYPE_BYTE, &byte_array_len_offset,
+                              &byte_array_data_offset, &byte_array_elem_size);
+  if (res != AIEXT_OK) {
+    return res;
+  }
+  res = env->get_array_layout(AIEXT_TYPE_INT, &int_array_len_offset,
+                              &int_array_data_offset, &int_array_elem_size);
+  if (res != AIEXT_OK) {
+    return res;
+  }
+
+  // Get narrow oop layout.
+  res = env->get_narrow_oop_layout(&narrow_null, &narrow_base, &narrow_shift);
+  if (res != AIEXT_OK) {
+    return res;
+  }
+
+#define REPLACE_WITH_NATIVE(m, s, f)                                          \
+  do {                                                                        \
+    aiext_result_t res;                                                       \
+    res = env->register_naccel_provider("TestAIExtension$Launcher", m, s, #f, \
+                                        f, NULL);                             \
+    if (res != AIEXT_OK) {                                                    \
+      return res;                                                             \
+    }                                                                         \
+  } while (0)
+#define REPLACE_WITH_PROVIDER(m, s, f)                                        \
+  do {                                                                        \
+    aiext_result_t res;                                                       \
+    res = env->register_naccel_provider("TestAIExtension$Launcher", m, s, #f, \
+                                        f, native_provider);                  \
+    if (res != AIEXT_OK) {                                                    \
+      return res;                                                             \
+    }                                                                         \
   } while (0)
 
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello", "()V", "hello",
-                      hello);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello", "(I)V", "hello_int",
-                      hello_int);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello", "(J)V", "hello_long",
-                      hello_long);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello", "(F)V",
-                      "hello_float", hello_float);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello", "(D)V",
-                      "hello_double", hello_double);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello", "([B)V",
-                      "hello_bytes", hello_bytes);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello",
-                      "(Ljava/lang/Object;)V", "hello_object", hello_object);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "hello", "(S)V",
-                      "hello_short_method", hello_short_method);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "add", "(II)I", "add_ints",
-                      add_ints);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "add", "(DD)D", "add_doubles",
-                      add_doubles);
-  REPLACE_WITH_NATIVE("TestAIExtension$Launcher", "add", "([I[I)V",
-                      "add_arrays", add_arrays);
+  REPLACE_WITH_NATIVE("hello", "()V", hello);
+  REPLACE_WITH_NATIVE("hello", "(I)V", hello_int);
+  REPLACE_WITH_NATIVE("hello", "(J)V", hello_long);
+  REPLACE_WITH_NATIVE("hello", "(F)V", hello_float);
+  REPLACE_WITH_NATIVE("hello", "(D)V", hello_double);
+  REPLACE_WITH_NATIVE("hello", "([B)V", hello_bytes);
+  REPLACE_WITH_NATIVE("hello", "(Ljava/lang/Object;)V", hello_object);
+  REPLACE_WITH_NATIVE("hello", "(S)V", hello_short_method);
+
+  REPLACE_WITH_NATIVE("add", "(II)I", add_ints);
+  REPLACE_WITH_NATIVE("add", "(DD)D", add_doubles);
+  REPLACE_WITH_NATIVE("add", "([I[I)V", add_arrays);
+
+  REPLACE_WITH_PROVIDER("add_to_int", "(I)V", add_to_int);
+  REPLACE_WITH_PROVIDER("add_to_double", "(D)V", add_to_double);
+
+  REPLACE_WITH_PROVIDER("should_skip", "()V", NULL);
+
+  REPLACE_WITH_PROVIDER("read_strs", "()V", read_strs);
+
+  REPLACE_WITH_PROVIDER("add_to_static_int", "(I)V", add_to_static_int);
+  REPLACE_WITH_PROVIDER("check_static_enum", "()V", check_static_enum);
 
 #undef REPLACE_WITH_NATIVE
+#undef REPLACE_WITH_PROVIDER
   return AIEXT_OK;
 }
 


### PR DESCRIPTION
Summary: The new AI-Extension API supports retrieving the narrow OOP layout and array layout of the JVM, as well as accessing fields and static fields of Java objects.

Testing: test/hotspot/jtreg/compiler/alibaba/TestAIExtension.java

Reviewers: kuaiwei, JoshuaZhuwj

Issue: https://github.com/dragonwell-project/dragonwell21/issues/291